### PR TITLE
Fix scalables from reserve GSK block to take Pmin and Pmax into account

### DIFF
--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -90,7 +90,7 @@ public final class GlskPointScalableConverter {
             percentages.add((float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor));
             scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
         });
-        return Scalable.proportional(percentages, scalables);
+        return Scalable.proportional(percentages, scalables, true);
     }
 
     private static double getRemainingCapacityUp(AbstractGlskRegisteredResource resource, Network network) {

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -88,7 +88,7 @@ public final class GlskPointScalableConverter {
         double totalFactor = generatorResources.stream().mapToDouble(resource -> remainingCapacityFunction.apply(resource, network)).sum();
         generatorResources.forEach(generatorResource -> {
             percentages.add((float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor));
-            scalables.add(Scalable.onGenerator(generatorResource.getGeneratorId()));
+            scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
         });
         return Scalable.proportional(percentages, scalables);
     }

--- a/glsk/glsk-document-cse/src/test/java/com/powsybl/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/glsk/glsk-document-cse/src/test/java/com/powsybl/glsk/cse/CseGlskDocumentImporterTest.java
@@ -66,12 +66,28 @@ public class CseGlskDocumentImporterTest {
         Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
 
         assertNotNull(reserveScalable);
-        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
 
-        reserveScalable.scale(network, -900.);
-        assertEquals(1400., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(1700., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(-900, reserveScalable.scale(network, -900), EPSILON);
+        assertEquals(1400, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1700, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertReserveGskBlocksDownWithReachingLimits() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
+
+        assertNotNull(reserveScalable);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+
+        // 1000 MW missing for down-scaling
+        assertEquals(-3000, reserveScalable.scale(network, -4000), EPSILON);
+        assertEquals(0, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
     }
 
     @Test
@@ -81,12 +97,28 @@ public class CseGlskDocumentImporterTest {
         Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
 
         assertNotNull(reserveScalable);
-        assertEquals(2000., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
 
-        reserveScalable.scale(network, 1000.);
-        assertEquals(2600., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
-        assertEquals(2400., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, reserveScalable.scale(network, 1000), EPSILON);
+        assertEquals(2600, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2400, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+    }
+
+    @Test
+    public void checkCseGlskDocumentImporterCorrectlyConvertReserveGskBlocksUpWithReachingLimits() {
+        Network network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlsk.xml"));
+        Scalable reserveScalable = glskDocument.getZonalScalable(network).getData("FR_RESERVE");
+
+        assertNotNull(reserveScalable);
+        assertEquals(2000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
+
+        // 1000 MW missing for up-scaling
+        assertEquals(5000, reserveScalable.scale(network, 6000), EPSILON);
+        assertEquals(5000, network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(4000, network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
     }
 
     @Test
@@ -231,5 +263,4 @@ public class CseGlskDocumentImporterTest {
         assertEquals(4000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
         assertEquals(6000., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
     }
-
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix


**What is the current behavior?** *(You can also link to an open issue here)*
When declaring a scalable on a generator Pmin and Pmax values can be set. When converting GLSK point to scalable in case of reserve GLSK block, the Pmin and Pmax parameters are not used to limit generators scalables.


**What is the new behavior (if this is a feature change)?**
We want to use values that present in the GLSK point to reduce available range of generator scalable in case of a reserve GLSK block. We also want to make the proportional scalable created for reserve GLSK block iteratove otherwise target is not reached most of the time.