### PR TITLE
[GLSK import] Remove elements that don't participate to scalable ventilation

### DIFF
--- a/glsk/glsk-document-api/pom.xml
+++ b/glsk/glsk-document-api/pom.xml
@@ -32,6 +32,22 @@
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-sensitivity-analysis-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-xml-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/EmptyScalable.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/EmptyScalable.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.glsk.api.util.converters;
 
 import com.powsybl.action.util.Scalable;

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/EmptyScalable.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/EmptyScalable.java
@@ -1,0 +1,84 @@
+package com.powsybl.glsk.api.util.converters;
+
+import com.powsybl.action.util.Scalable;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Injection;
+import com.powsybl.iidm.network.Network;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ */
+public class EmptyScalable implements Scalable {
+    @Override
+    public double initialValue(Network network) {
+        return 0;
+    }
+
+    @Override
+    public void reset(Network network) {
+
+    }
+
+    @Override
+    public double maximumValue(Network network) {
+        return 0;
+    }
+
+    @Override
+    public double minimumValue(Network network) {
+        return 0;
+    }
+
+    @Override
+    public double maximumValue(Network network, ScalingConvention scalingConvention) {
+        return 0;
+    }
+
+    @Override
+    public double minimumValue(Network network, ScalingConvention scalingConvention) {
+        return 0;
+    }
+
+    @Override
+    public void listGenerators(Network network, List<Generator> list, List<String> list1) {
+
+    }
+
+    @Override
+    public List<Generator> listGenerators(Network network, List<String> list) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Generator> listGenerators(Network network) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void filterInjections(Network network, List<Injection> list, List<String> list1) {
+
+    }
+
+    @Override
+    public List<Injection> filterInjections(Network network, List<String> list) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<Injection> filterInjections(Network network) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public double scale(Network network, double v) {
+        return 0;
+    }
+
+    @Override
+    public double scale(Network network, double v, ScalingConvention scalingConvention) {
+        return 0;
+    }
+}

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/EmptyScalable.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/EmptyScalable.java
@@ -25,7 +25,7 @@ public class EmptyScalable implements Scalable {
 
     @Override
     public void reset(Network network) {
-
+        // Nothing to do
     }
 
     @Override
@@ -50,7 +50,7 @@ public class EmptyScalable implements Scalable {
 
     @Override
     public void listGenerators(Network network, List<Generator> list, List<String> list1) {
-
+        // Nothing to do
     }
 
     @Override
@@ -65,7 +65,7 @@ public class EmptyScalable implements Scalable {
 
     @Override
     public void filterInjections(Network network, List<Injection> list, List<String> list1) {
-
+        // Nothing to do
     }
 
     @Override

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -95,6 +95,7 @@ public final class GlskPointScalableConverter {
         double totalFactor = generatorResources.stream().mapToDouble(resource -> remainingCapacityFunction.apply(resource, network)).sum();
         generatorResources.forEach(generatorResource -> {
             float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor);
+            // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
             if (generatorPercentage > 0) {
                 percentages.add(generatorPercentage);
                 scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
@@ -188,6 +189,7 @@ public final class GlskPointScalableConverter {
             //calculate factor of each generator
             generators.forEach(generator -> {
                 float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoTargetP(generator) / totalCountryP);
+                // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
                 if (generatorPercentage > 0) {
                     percentages.add(generatorPercentage);
                     scalables.add(Scalable.onGenerator(generator.getId()));
@@ -203,6 +205,7 @@ public final class GlskPointScalableConverter {
             double totalCountryP = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
             loads.forEach(load -> {
                 float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoP0(load) / totalCountryP);
+                // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
                 if (loadPercentage > 0) {
                     percentages.add(loadPercentage);
                     scalables.add(Scalable.onLoad(load.getId()));
@@ -232,6 +235,7 @@ public final class GlskPointScalableConverter {
             generators.forEach(generator -> {
                 // Calculate factor of each generator
                 float factor = (float) (glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoTargetP(generator) / totalP);
+                // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
                 if (factor > 0) {
                     percentages.add(100 * factor);
                     // In case of global shift key limitation we will limit the generator proportionally to
@@ -251,6 +255,7 @@ public final class GlskPointScalableConverter {
 
             loads.forEach(load -> {
                 float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoP0(load) / totalP);
+                // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
                 if (loadPercentage > 0) {
                     // For now glsk shift key maximum shift is not handled for loads by lack of specification
                     percentages.add(loadPercentage);
@@ -279,6 +284,7 @@ public final class GlskPointScalableConverter {
 
             generatorResources.forEach(generatorResource -> {
                 float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * generatorResource.getParticipationFactor() / totalFactor);
+                // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
                 if (generatorPercentage > 0) {
                     percentages.add(generatorPercentage);
                     scalables.add(Scalable.onGenerator(generatorResource.getGeneratorId()));
@@ -294,6 +300,7 @@ public final class GlskPointScalableConverter {
 
             loadResources.forEach(loadResource -> {
                 float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * loadResource.getParticipationFactor() / totalFactor);
+                // FIXME: this filter can be removed once not participating elements are better handled in ProportionalScalable
                 if (loadPercentage > 0) {
                     percentages.add(loadPercentage);
                     scalables.add(Scalable.onLoad(loadResource.getLoadId()));

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -68,6 +68,9 @@ public final class GlskPointScalableConverter {
                 throw new GlskException("In convert glskShiftKey business type not supported");
             }
         }
+        if (percentages.isEmpty()) {
+            return new EmptyScalable();
+        }
         return Scalable.proportional(percentages, scalables, true);
     }
 
@@ -91,21 +94,27 @@ public final class GlskPointScalableConverter {
         List<Scalable> scalables = new ArrayList<>();
         double totalFactor = generatorResources.stream().mapToDouble(resource -> remainingCapacityFunction.apply(resource, network)).sum();
         generatorResources.forEach(generatorResource -> {
-            percentages.add((float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor));
-            scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
+            float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor);
+            if (generatorPercentage > 0) {
+                percentages.add(generatorPercentage);
+                scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
+            }
         });
+        if (percentages.isEmpty()) {
+            return new EmptyScalable();
+        }
         return Scalable.proportional(percentages, scalables, true);
     }
 
     private static double getRemainingCapacityUp(AbstractGlskRegisteredResource resource, Network network) {
         Generator generator = network.getGenerator(resource.getGeneratorId());
-        double maxP = resource.getMaximumCapacity().orElse(generator.getMaxP());
+        double maxP = Math.min(resource.getMaximumCapacity().orElse(generator.getMaxP()), generator.getMaxP());
         return Math.max(0., maxP - NetworkUtil.pseudoTargetP(generator));
     }
 
     private static double getRemainingCapacityDown(AbstractGlskRegisteredResource resource, Network network) {
         Generator generator = network.getGenerator(resource.getGeneratorId());
-        double minP = resource.getMinimumCapacity().orElse(generator.getMinP());
+        double minP = Math.max(resource.getMinimumCapacity().orElse(generator.getMinP()), generator.getMinP());
         return Math.max(0, NetworkUtil.pseudoTargetP(generator) - minP);
     }
 
@@ -177,8 +186,13 @@ public final class GlskPointScalableConverter {
             //calculate sum P of country's generators
             double totalCountryP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
             //calculate factor of each generator
-            generators.forEach(generator -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoTargetP(generator) / (float) totalCountryP));
-            generators.forEach(generator -> scalables.add(Scalable.onGenerator(generator.getId())));
+            generators.forEach(generator -> {
+                float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoTargetP(generator) / totalCountryP);
+                if (generatorPercentage > 0) {
+                    percentages.add(generatorPercentage);
+                    scalables.add(Scalable.onGenerator(generator.getId()));
+                }
+            });
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             LOGGER.debug("GLSK Type B42, empty registered resources list --> country (proportional) LSK");
             List<Load> loads = network.getLoadStream()
@@ -187,8 +201,13 @@ public final class GlskPointScalableConverter {
                     .collect(Collectors.toList());
             //calculate sum P of country's loads
             double totalCountryP = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
-            loads.forEach(load -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoP0(load) / (float) totalCountryP));
-            loads.forEach(load -> scalables.add(Scalable.onLoad(load.getId(), -Double.MAX_VALUE, Double.MAX_VALUE)));
+            loads.forEach(load -> {
+                float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoP0(load) / totalCountryP);
+                if (loadPercentage > 0) {
+                    percentages.add(loadPercentage);
+                    scalables.add(Scalable.onLoad(load.getId()));
+                }
+            });
         }
     }
 
@@ -212,12 +231,14 @@ public final class GlskPointScalableConverter {
 
             generators.forEach(generator -> {
                 // Calculate factor of each generator
-                float factor = glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoTargetP(generator) / (float) totalP;
-                percentages.add(100 * factor);
-                // In case of global shift key limitation we will limit the generator proportionally to
-                // its participation in the global proportional scalable
-                double maxGeneratorValue = NetworkUtil.pseudoTargetP(generator) + factor * glskShiftKey.getMaximumShift();
-                scalables.add(Scalable.onGenerator(generator.getId(), -Double.MAX_VALUE, maxGeneratorValue));
+                float factor = (float) (glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoTargetP(generator) / totalP);
+                if (factor > 0) {
+                    percentages.add(100 * factor);
+                    // In case of global shift key limitation we will limit the generator proportionally to
+                    // its participation in the global proportional scalable
+                    double maxGeneratorValue = NetworkUtil.pseudoTargetP(generator) + factor * glskShiftKey.getMaximumShift();
+                    scalables.add(Scalable.onGenerator(generator.getId(), -Double.MAX_VALUE, maxGeneratorValue));
+                }
             });
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             LOGGER.debug("GLSK Type B42, not empty registered resources list --> (explicit/manual) proportional LSK");
@@ -228,9 +249,14 @@ public final class GlskPointScalableConverter {
                     .collect(Collectors.toList());
             double totalP = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
 
-            // For now glsk shift key maximum shift is not handled for loads by lack of specification
-            loads.forEach(load -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) NetworkUtil.pseudoP0(load) / (float) totalP));
-            loads.forEach(load -> scalables.add(Scalable.onLoad(load.getId(), -Double.MAX_VALUE, Double.MAX_VALUE)));
+            loads.forEach(load -> {
+                float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoP0(load) / totalP);
+                if (loadPercentage > 0) {
+                    // For now glsk shift key maximum shift is not handled for loads by lack of specification
+                    percentages.add(loadPercentage);
+                    scalables.add(Scalable.onLoad(load.getId()));
+                }
+            });
         }
     }
 
@@ -251,8 +277,13 @@ public final class GlskPointScalableConverter {
 
             double totalFactor = generatorResources.stream().mapToDouble(AbstractGlskRegisteredResource::getParticipationFactor).sum();
 
-            generatorResources.forEach(generatorResource -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) generatorResource.getParticipationFactor() / (float) totalFactor));
-            generatorResources.forEach(generatorResource -> scalables.add(Scalable.onGenerator(generatorResource.getGeneratorId())));
+            generatorResources.forEach(generatorResource -> {
+                float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * generatorResource.getParticipationFactor() / totalFactor);
+                if (generatorPercentage > 0) {
+                    percentages.add(generatorPercentage);
+                    scalables.add(Scalable.onGenerator(generatorResource.getGeneratorId()));
+                }
+            });
         } else if (glskShiftKey.getPsrType().equals("A05")) {
             LOGGER.debug("GLSK Type B43 LSK");
             List<AbstractGlskRegisteredResource> loadResources = glskShiftKey.getRegisteredResourceArrayList().stream()
@@ -261,8 +292,13 @@ public final class GlskPointScalableConverter {
 
             double totalFactor = loadResources.stream().mapToDouble(AbstractGlskRegisteredResource::getParticipationFactor).sum();
 
-            loadResources.forEach(loadResource -> percentages.add(100 * glskShiftKey.getQuantity().floatValue() * (float) loadResource.getParticipationFactor() / (float) totalFactor));
-            loadResources.forEach(loadResource -> scalables.add(Scalable.onLoad(loadResource.getLoadId(), -Double.MAX_VALUE, Double.MAX_VALUE)));
+            loadResources.forEach(loadResource -> {
+                float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * loadResource.getParticipationFactor() / totalFactor);
+                if (loadPercentage > 0) {
+                    percentages.add(loadPercentage);
+                    scalables.add(Scalable.onLoad(loadResource.getLoadId()));
+                }
+            });
         }
     }
 

--- a/glsk/glsk-document-api/src/test/java/com/powsybl/glsk/api/util/converters/EmptyScalableTest.java
+++ b/glsk/glsk-document-api/src/test/java/com/powsybl/glsk/api/util/converters/EmptyScalableTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.glsk.api.util.converters;
+
+import com.powsybl.action.util.Scalable;
+import com.powsybl.iidm.import_.Importers;
+import com.powsybl.iidm.network.Network;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Joris Mancini {@literal <joris.mancini at rte-france.com>}
+ */
+public class EmptyScalableTest {
+
+    private EmptyScalable scalable;
+    private Network network;
+
+    @Before
+    public void setUp() {
+        scalable = new EmptyScalable();
+        network = Importers.loadNetwork("testCase.xiidm", getClass().getResourceAsStream("testCase.xiidm"));
+    }
+
+    @Test
+    public void testInitialValue() {
+        assertEquals(0, scalable.initialValue(network), 1);
+    }
+
+    @Test
+    public void testMaximumValues() {
+        assertEquals(0, scalable.maximumValue(network), 1);
+        assertEquals(0, scalable.maximumValue(network, Scalable.ScalingConvention.GENERATOR), 1);
+        assertEquals(0, scalable.maximumValue(network, Scalable.ScalingConvention.LOAD), 1);
+    }
+
+    @Test
+    public void testMinimumValues() {
+        assertEquals(0, scalable.minimumValue(network), 1);
+        assertEquals(0, scalable.minimumValue(network, Scalable.ScalingConvention.GENERATOR), 1);
+        assertEquals(0, scalable.minimumValue(network, Scalable.ScalingConvention.LOAD), 1);
+    }
+
+    @Test
+    public void testListGenerators() {
+        assertEquals(0, scalable.listGenerators(network).size());
+    }
+
+    @Test
+    public void testScale() {
+        assertEquals(0, scalable.scale(network, 500), 1);
+        assertEquals(0, scalable.scale(network, -500), 1);
+        assertEquals(0, scalable.scale(network, 500, Scalable.ScalingConvention.GENERATOR), 1);
+        assertEquals(0, scalable.scale(network, -500, Scalable.ScalingConvention.GENERATOR), 1);
+        assertEquals(0, scalable.scale(network, 500, Scalable.ScalingConvention.LOAD), 1);
+        assertEquals(0, scalable.scale(network, -500, Scalable.ScalingConvention.LOAD), 1);
+    }
+}

--- a/glsk/glsk-document-api/src/test/resources/com/powsybl/glsk/api/util/converters/testCase.xiidm
+++ b/glsk/glsk-document-api/src/test/resources/com/powsybl/glsk/api/util/converters/testCase.xiidm
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="20140116_0830_2D4_UX1_pst" caseDate="2014-01-16T08:30:00.000+01:00" forecastDistance="0" sourceFormat="UCTE">
+    <iidm:substation id="BBE1AA" country="BE">
+        <iidm:voltageLevel id="BBE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE1AA1 " v="380.0" angle="-2.353799343109131"/>
+                <iidm:bus id="BBE3AA1 " v="380.0" angle="0.0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="BBE3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE1AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 " p="3000.0"/>
+            <iidm:load id="BBE3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 " p="1500.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="BBE1AA1  BBE3AA1  2" r="0.20800000429153442" x="25.5" g="1.0625000186337274E-6" b="-2.1624998680636054E-6" ratedU1="400.0" ratedU2="400.0" bus1="BBE3AA1 " connectableBus1="BBE3AA1 " voltageLevelId1="BBE1AA1" bus2="BBE1AA1 " connectableBus2="BBE1AA1 " voltageLevelId2="BBE1AA1" p1="-227.49346923828125" p2="227.49346923828125">
+            <iidm:phaseTapChanger lowTapPosition="-33" tapPosition="5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="30.036436080932617"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="29.165605545043945"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="28.29132080078125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="27.413660049438477"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="26.53270721435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="25.648548126220703"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="24.761274337768555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="23.870973587036133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="22.977739334106445"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="22.0816650390625"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="21.182849884033203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="20.281387329101562"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="19.377382278442383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="18.470935821533203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="17.56215476989746"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="16.651138305664062"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="15.737995147705078"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="14.82283878326416"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="13.905777931213379"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="12.986922264099121"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="12.066386222839355"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.144285202026367"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.220732688903809"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.295848846435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="8.369750022888184"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="7.442552089691162"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.514379024505615"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.585349082946777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.655583381652832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.7252047061920166"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.7943341732025146"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.8630945682525635"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.9316088557243347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.9316088557243347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.8630945682525635"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.7943341732025146"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.7252047061920166"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.655583381652832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.585349082946777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.514379024505615"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-7.442552089691162"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-8.369750022888184"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-9.295848846435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.220732688903809"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-11.144285202026367"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-12.066386222839355"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-12.986922264099121"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-13.905777931213379"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-14.82283878326416"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-15.737995147705078"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-16.651138305664062"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-17.56215476989746"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-18.470935821533203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-19.377382278442383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.281387329101562"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-21.182849884033203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-22.0816650390625"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-22.977739334106445"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-23.870973587036133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-24.761274337768555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.648548126220703"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-26.53270721435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-27.413660049438477"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-28.29132080078125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-29.165605545043945"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-30.036436080932617"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="1227.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="BBE2AA" country="BE">
+        <iidm:voltageLevel id="BBE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE2AA1 " v="380.0" angle="2.1468396186828613"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="-0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 " p="-3000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE1AA" country="DE">
+        <iidm:voltageLevel id="DDE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE1AA1 " v="380.0" angle="-13.329349517822266"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE1AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 " p="3500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE2AA" country="DE">
+        <iidm:voltageLevel id="DDE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE2AA1 " v="380.0" angle="-11.774831771850586"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE2AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 " p="3000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE3AA" country="DE">
+        <iidm:voltageLevel id="DDE3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE3AA1 " v="380.0" angle="-10.916015625"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE3AA1 _load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 " p="2000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR1AA" country="FR">
+        <iidm:voltageLevel id="FFR1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR1AA1 " v="380.0" angle="0.13716478645801544"/>
+                <iidm:bus id="FFR2AA1 " v="380.0" angle="-5.659938335418701"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FFR2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 " p="1000.0"/>
+            <iidm:load id="FFR2AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 " p="3500.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FFR1AA1  FFR2AA1  2" r="0.08669999986886978" x="13.98799991607666" g="1.2216000868647825E-6" b="-2.3275001694855746E-6" ratedU1="400.0" ratedU2="400.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="FFR1AA1 " connectableBus2="FFR1AA1 " voltageLevelId2="FFR1AA1" p1="279.1942443847656" p2="-279.1942443847656">
+            <iidm:phaseTapChanger lowTapPosition="-17" tapPosition="-5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="24.626773834228516"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="23.21863555908203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="21.803354263305664"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="20.38130760192871"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="18.95288848876953"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="17.51850128173828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="16.07855987548828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="14.633487701416016"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="13.183723449707031"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.729705810546875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.27188777923584"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="8.81072998046875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="7.346695423126221"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.880255699157715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.411885738372803"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.9420645236968994"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.471274733543396"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.471274733543396"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.9420645236968994"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.411885738372803"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.880255699157715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-7.346695423126221"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-8.81072998046875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.27188777923584"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-11.729705810546875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-13.183723449707031"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-14.633487701416016"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-16.07855987548828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-17.51850128173828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-18.95288848876953"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.38130760192871"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-21.803354263305664"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-23.21863555908203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-24.626773834228516"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="2329.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FFR3AA" country="FR">
+        <iidm:voltageLevel id="FFR3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR3AA1 " v="380.0" angle="0.8586146235466003"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="-0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 " p="-3000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 " p="1500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL1AA" country="NL">
+        <iidm:voltageLevel id="NNL1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL1AA1 " v="380.0" angle="-4.895452976226807"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL2AA" country="NL">
+        <iidm:voltageLevel id="NNL2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL2AA1 " v="380.0" angle="-4.663552761077881"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="-0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 " p="-500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL3AA" country="NL">
+        <iidm:voltageLevel id="NNL3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL3AA1 " v="380.0" angle="-7.111279010772705"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL3AA1 _load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 " p="2500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="BBE1AA1  BBE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE2AA1 " connectableBus2="BBE2AA1 " voltageLevelId2="BBE2AA1" p1="-1134.2760009765625" p2="1134.2760009765625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="-593.217529296875" p2="593.217529296875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="541.0584106445312" p2="-541.0584106445312">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR2AA1 " connectableBus2="FFR2AA1 " voltageLevelId2="FFR1AA1" p1="1461.01806640625" p2="-1461.01806640625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="-181.82379150390625" p2="181.82379150390625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="-1642.841796875" p2="1642.841796875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE2AA1 " connectableBus2="DDE2AA1 " voltageLevelId2="DDE2AA1" p1="-391.77813720703125" p2="391.77813720703125">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="-608.2218627929688" p2="608.2218627929688">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="-216.44374084472656" p2="216.44374084472656">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL2AA1 " connectableBus2="NNL2AA1 " voltageLevelId2="NNL2AA1" p1="-58.444793701171875" p2="58.444793701171875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="558.44482421875" p2="-558.44482421875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="616.8895874023438" p2="-616.8895874023438">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="1324.6656494140625" p2="-1324.6656494140625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="-1175.3343505859375" p2="1175.3343505859375">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="-1175.3343505859375" p2="1175.3343505859375">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="324.6656188964844" p2="-324.6656188964844">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+</iidm:network>

--- a/glsk/glsk-document-cse/src/test/java/com/powsybl/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/glsk/glsk-document-cse/src/test/java/com/powsybl/glsk/cse/CseGlskDocumentImporterTest.java
@@ -314,4 +314,27 @@ public class CseGlskDocumentImporterTest {
         assertEquals(2000., network.getGenerator("FFR2AA1 _generator").getTargetP(), EPSILON);
         assertEquals(2500., network.getGenerator("FFR3AA1 _generator").getTargetP(), EPSILON);
     }
+
+    @Test
+    public void checkRemainingCapacityWithDifferentKindOfInitialLimitations() {
+        // BBE1 has initially no remaining up capacity due to network limitation but BBE3 has remaining up capacity
+        // NNL1 has initially no remaining up capacity due to GLSK limits but NNL2 has remaining up capacity
+        // FFR1 has initially no remaining up capacity due to network limitation and FFR2 has initially no remaining up capacity due to GLSK limits
+        Network network = Importers.loadNetwork("testCaseWithInitialLimits.xiidm", getClass().getResourceAsStream("/testCaseWithInitialLimits.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlskWithInitialLimits.xml"));
+
+        assertEquals(1500, network.getGenerator("BBE1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(2500, network.getGenerator("BBE3AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(6500, glskDocument.getZonalScalable(network).getData("BE_RESERVE").scale(network, 10000), EPSILON);
+        assertEquals(1500, network.getGenerator("BBE1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(9000, network.getGenerator("BBE3AA1 _generator").getTargetP(), EPSILON);
+
+        assertEquals(1500, network.getGenerator("NNL1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(500, network.getGenerator("NNL2AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(500, glskDocument.getZonalScalable(network).getData("NL_RESERVE").scale(network, 500), EPSILON);
+        assertEquals(1500, network.getGenerator("NNL1AA1 _generator").getTargetP(), EPSILON);
+        assertEquals(1000, network.getGenerator("NNL2AA1 _generator").getTargetP(), EPSILON);
+
+        assertEquals(0, glskDocument.getZonalScalable(network).getData("FR_RESERVE").scale(network, 6000), EPSILON);
+    }
 }

--- a/glsk/glsk-document-cse/src/test/resources/testCaseWithInitialLimits.xiidm
+++ b/glsk/glsk-document-cse/src/test/resources/testCaseWithInitialLimits.xiidm
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.itesla_project.eu/schema/iidm/1_0" id="20140116_0830_2D4_UX1_pst" caseDate="2014-01-16T08:30:00.000+01:00" forecastDistance="0" sourceFormat="UCTE">
+    <iidm:substation id="BBE1AA" country="BE">
+        <iidm:voltageLevel id="BBE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE1AA1 " v="380.0" angle="-2.353799343109131"/>
+                <iidm:bus id="BBE3AA1 " v="380.0" angle="0.0"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="1500.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="BBE3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE1AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 " p="3000.0"/>
+            <iidm:load id="BBE3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 " p="1500.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="BBE1AA1  BBE3AA1  2" r="0.20800000429153442" x="25.5" g="1.0625000186337274E-6" b="-2.1624998680636054E-6" ratedU1="400.0" ratedU2="400.0" bus1="BBE3AA1 " connectableBus1="BBE3AA1 " voltageLevelId1="BBE1AA1" bus2="BBE1AA1 " connectableBus2="BBE1AA1 " voltageLevelId2="BBE1AA1" p1="-227.49346923828125" p2="227.49346923828125">
+            <iidm:phaseTapChanger lowTapPosition="-33" tapPosition="5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="30.036436080932617"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="29.165605545043945"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="28.29132080078125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="27.413660049438477"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="26.53270721435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="25.648548126220703"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="24.761274337768555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="23.870973587036133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="22.977739334106445"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="22.0816650390625"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="21.182849884033203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="20.281387329101562"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="19.377382278442383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="18.470935821533203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="17.56215476989746"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="16.651138305664062"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="15.737995147705078"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="14.82283878326416"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="13.905777931213379"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="12.986922264099121"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="12.066386222839355"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.144285202026367"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.220732688903809"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="9.295848846435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="8.369750022888184"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="7.442552089691162"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.514379024505615"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.585349082946777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.655583381652832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.7252047061920166"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.7943341732025146"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.8630945682525635"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.9316088557243347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.9316088557243347"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.8630945682525635"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.7943341732025146"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.7252047061920166"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.655583381652832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.585349082946777"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.514379024505615"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-7.442552089691162"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-8.369750022888184"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-9.295848846435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.220732688903809"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-11.144285202026367"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-12.066386222839355"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-12.986922264099121"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-13.905777931213379"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-14.82283878326416"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-15.737995147705078"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-16.651138305664062"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-17.56215476989746"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-18.470935821533203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-19.377382278442383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.281387329101562"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-21.182849884033203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-22.0816650390625"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-22.977739334106445"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-23.870973587036133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-24.761274337768555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-25.648548126220703"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-26.53270721435547"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-27.413660049438477"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-28.29132080078125"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-29.165605545043945"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-30.036436080932617"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="1227.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="BBE2AA" country="BE">
+        <iidm:voltageLevel id="BBE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE2AA1 " v="380.0" angle="2.1468396186828613"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="-0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 " p="-3000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE1AA" country="DE">
+        <iidm:voltageLevel id="DDE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE1AA1 " v="380.0" angle="-13.329349517822266"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE1AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 " p="3500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE2AA" country="DE">
+        <iidm:voltageLevel id="DDE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE2AA1 " v="380.0" angle="-11.774831771850586"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE2AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 " p="3000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE3AA" country="DE">
+        <iidm:voltageLevel id="DDE3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE3AA1 " v="380.0" angle="-10.916015625"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE3AA1 _load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 " p="2000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR1AA" country="FR">
+        <iidm:voltageLevel id="FFR1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR1AA1 " v="380.0" angle="0.13716478645801544"/>
+                <iidm:bus id="FFR2AA1 " v="380.0" angle="-5.659938335418701"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="2000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FFR2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="-0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 " p="-2000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 " p="1000.0"/>
+            <iidm:load id="FFR2AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 " p="3500.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FFR1AA1  FFR2AA1  2" r="0.08669999986886978" x="13.98799991607666" g="1.2216000868647825E-6" b="-2.3275001694855746E-6" ratedU1="400.0" ratedU2="400.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="FFR1AA1 " connectableBus2="FFR1AA1 " voltageLevelId2="FFR1AA1" p1="279.1942443847656" p2="-279.1942443847656">
+            <iidm:phaseTapChanger lowTapPosition="-17" tapPosition="-5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="24.626773834228516"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="23.21863555908203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="21.803354263305664"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="20.38130760192871"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="18.95288848876953"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="17.51850128173828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="16.07855987548828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="14.633487701416016"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="13.183723449707031"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="11.729705810546875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="10.27188777923584"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="8.81072998046875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="7.346695423126221"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.880255699157715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.411885738372803"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.9420645236968994"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.471274733543396"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.471274733543396"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.9420645236968994"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.411885738372803"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.880255699157715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-7.346695423126221"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-8.81072998046875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-10.27188777923584"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-11.729705810546875"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-13.183723449707031"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-14.633487701416016"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-16.07855987548828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-17.51850128173828"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-18.95288848876953"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-20.38130760192871"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-21.803354263305664"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-23.21863555908203"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-24.626773834228516"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="2329.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FFR3AA" country="FR">
+        <iidm:voltageLevel id="FFR3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR3AA1 " v="380.0" angle="0.8586146235466003"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="3000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="-0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 " p="-3000.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 " p="1500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL1AA" country="NL">
+        <iidm:voltageLevel id="NNL1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL1AA1 " v="380.0" angle="-4.895452976226807"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL1AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="-0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 " p="-1500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL2AA" country="NL">
+        <iidm:voltageLevel id="NNL2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL2AA1 " v="380.0" angle="-4.663552761077881"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL2AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="-0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 " p="-500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 " p="1000.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL3AA" country="NL">
+        <iidm:voltageLevel id="NNL3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL3AA1 " v="380.0" angle="-7.111279010772705"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL3AA1 _generator" energySource="OTHER" minP="-0.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="-0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 " p="-2500.0">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL3AA1 _load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 " p="2500.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="BBE1AA1  BBE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE2AA1 " connectableBus2="BBE2AA1 " voltageLevelId2="BBE2AA1" p1="-1134.2760009765625" p2="1134.2760009765625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="-593.217529296875" p2="593.217529296875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="541.0584106445312" p2="-541.0584106445312">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR2AA1 " connectableBus2="FFR2AA1 " voltageLevelId2="FFR1AA1" p1="1461.01806640625" p2="-1461.01806640625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="-181.82379150390625" p2="181.82379150390625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="-1642.841796875" p2="1642.841796875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE2AA1 " connectableBus2="DDE2AA1 " voltageLevelId2="DDE2AA1" p1="-391.77813720703125" p2="391.77813720703125">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="-608.2218627929688" p2="608.2218627929688">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="-216.44374084472656" p2="216.44374084472656">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL2AA1 " connectableBus2="NNL2AA1 " voltageLevelId2="NNL2AA1" p1="-58.444793701171875" p2="58.444793701171875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="558.44482421875" p2="-558.44482421875">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="616.8895874023438" p2="-616.8895874023438">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1" p1="1324.6656494140625" p2="-1324.6656494140625">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1" p1="-1175.3343505859375" p2="1175.3343505859375">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE1AA1" p1="-1175.3343505859375" p2="1175.3343505859375">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1" p1="324.6656188964844" p2="-324.6656188964844">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+</iidm:network>

--- a/glsk/glsk-document-cse/src/test/resources/testGlskWithInitialLimits.xml
+++ b/glsk/glsk-document-cse/src/test/resources/testGlskWithInitialLimits.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GSKDocument DtdVersion="5" DtdRelease="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gsk-document.xsd">
+    <DocumentIdentification v="testGlsk"/>
+    <DocumentVersion v="1"/>
+    <DocumentType v="Z02"/>
+    <ProcessType v="Z02"/>
+    <SenderIdentification v="10VCSEEH4MMD-NDO" codingScheme="A01"/>
+    <SenderRole v="A36"/>
+    <ReceiverIdentification v="10X1001A1001A345" codingScheme="A01"/>
+    <ReceiverRole v="A04"/>
+    <CreationDateTime v="2020-09-15T17:59:09Z"/>
+    <GSKTimeInterval v="2020-09-16T22:00Z/2020-09-16T23:00Z"/>
+    <Domain v="10YDOM-1001A061T" codingScheme="A01"/>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="BE_RESERVE" codingScheme="A01"/>
+        <Name v="BE_RESERVE"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <ReserveGSKBlock>
+            <Factor v="1"/>
+            <Node>
+                <Name v="BBE1AA1 "/>
+                <Pmin v="0"/>
+                <Pmax v="-9000"/>
+            </Node>
+            <Node>
+                <Name v="BBE3AA1 "/>
+                <Pmin v="-1000"/>
+                <Pmax v="-9000"/>
+            </Node>
+        </ReserveGSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="NL_RESERVE" codingScheme="A01"/>
+        <Name v="NL_RESERVE"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <ReserveGSKBlock>
+            <Factor v="1"/>
+            <Node>
+                <Name v="NNL1AA1 "/>
+                <Pmin v="0"/>
+                <Pmax v="-1500"/>
+            </Node>
+            <Node>
+                <Name v="NNL2AA1 "/>
+                <Pmin v="-1000"/>
+                <Pmax v="-9000"/>
+            </Node>
+        </ReserveGSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_RESERVE" codingScheme="A01"/>
+        <Name v="FR_RESERVE"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <ReserveGSKBlock>
+            <Factor v="1"/>
+            <Node>
+                <Name v="FFR1AA1 "/>
+                <Pmin v="0"/>
+                <Pmax v="-9000"/>
+            </Node>
+            <Node>
+                <Name v="FFR2AA1 "/>
+                <Pmin v="-1000"/>
+                <Pmax v="-2000"/>
+            </Node>
+        </ReserveGSKBlock>
+    </TimeSeries>
+</GSKDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Fix a very specific behavior that can cause a crash. It happens when initially some elements are added to a proportional scalable (generator or load scalable) with a percentage of participation of 0%. By construction they are set up has `not saturated` when they kind of are. When iterations are done to scale, if these elements are the only remaining unsaturated elements sum of percentages is null then it could lead to set NaN values on generators and loads.   


**What is the current behavior?** *(You can also link to an open issue here)*
Currently we had injections to proportional scalable percentage list even if the percentage is null (meaning the element doesn't participate to the scaling)


**What is the new behavior (if this is a feature change)?**
Now we filter out elements that doesn't participate. Additionally it led to handle the case where no elements are effectively participating. Then a new Scalable implementation has been done, EmptyScalable. 

