### PR TITLE
Revert "Ensure that mrid are used when importing GLSK CIM and not rdfid (#34)"

### DIFF
--- a/glsk/glsk-document-cim/src/main/java/com/powsybl/glsk/cim/CimGlskRegisteredResource.java
+++ b/glsk/glsk-document-cim/src/main/java/com/powsybl/glsk/cim/CimGlskRegisteredResource.java
@@ -19,24 +19,14 @@ public class CimGlskRegisteredResource extends AbstractGlskRegisteredResource {
 
     public CimGlskRegisteredResource(Element element) {
         Objects.requireNonNull(element);
-        this.mRID = removeRdfPrefix(element.getElementsByTagName("mRID").item(0).getTextContent());
+        this.mRID = element.getElementsByTagName("mRID").item(0).getTextContent();
         this.name = element.getElementsByTagName("name").item(0).getTextContent();
         this.participationFactor = getContentAsDoubleOrNull(element, "sK_ResourceCapacity.defaultCapacity");
         this.maximumCapacity = getContentAsDoubleOrNull(element, "resourceCapacity.maximumCapacity");
         this.minimumCapacity = getContentAsDoubleOrNull(element, "resourceCapacity.minimumCapacity");
     }
 
-    private static String removeRdfPrefix(String s) {
-        String s1 = s;
-        // rdf:ID is the mRID plus an underscore added at the beginning of the string
-        // We may decide if we want to preserve or not the underscore
-        if (s1.length() > 0 && s1.charAt(0) == '_') {
-            s1 = s1.substring(1);
-        }
-        return s1;
-    }
-
-    private static Double getContentAsDoubleOrNull(Element baseElement, String tag) {
+    private Double getContentAsDoubleOrNull(Element baseElement, String tag) {
         return baseElement.getElementsByTagName(tag).getLength() == 0 ? null :
                 Double.parseDouble(baseElement.getElementsByTagName(tag).item(0).getTextContent());
     }


### PR DESCRIPTION
This reverts commit d2446a0119cbf1b1f73374a48d085fbc58c11ac6.

Signed-off-by: VEDELAGO MIORA <miora.ralambotiana@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
We shouldn't try to correct faulty files: parameters can be changed in CGMES import

