### PR TITLE
Add flow decomposition parameters loading from powsybl config file

### DIFF
--- a/flow-decomposition/pom.xml
+++ b/flow-decomposition/pom.xml
@@ -16,6 +16,10 @@
     <dependencies>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-api</artifactId>
         </dependency>
         <dependency>
@@ -65,6 +69,11 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionParameters.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionParameters.java
@@ -6,6 +6,10 @@
  */
 package com.powsybl.flow_decomposition;
 
+import com.powsybl.commons.config.PlatformConfig;
+
+import java.util.Objects;
+
 /**
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
@@ -23,19 +27,41 @@ public class FlowDecompositionParameters {
     private static final boolean DEFAULT_ENABLE_LOSSES_COMPENSATION = DISABLE_LOSSES_COMPENSATION;
     private static final double DEFAULT_LOSSES_COMPENSATION_EPSILON = 1e-5;
     private static final double DEFAULT_SENSITIVITY_EPSILON = 1e-5;
-    private static final boolean DEFAULT_RESCALE_MODE = DISABLE_RESCALED_RESULTS;
+    private static final boolean DEFAULT_RESCALE_ENABLED = DISABLE_RESCALED_RESULTS;
     private boolean saveIntermediates;
     private boolean enableLossesCompensation;
     private double lossesCompensationEpsilon;
     private double sensitivityEpsilon;
     private boolean rescaleEnabled;
 
+    public static FlowDecompositionParameters load() {
+        return load(PlatformConfig.defaultConfig());
+    }
+
+    public static FlowDecompositionParameters load(PlatformConfig platformConfig) {
+        FlowDecompositionParameters parameters = new FlowDecompositionParameters();
+        load(parameters, platformConfig);
+        return parameters;
+    }
+
+    private static void load(FlowDecompositionParameters parameters, PlatformConfig platformConfig) {
+        Objects.requireNonNull(parameters);
+        Objects.requireNonNull(platformConfig);
+        platformConfig.getOptionalModuleConfig("flow-decomposition-default-parameters").ifPresent(moduleConfig -> {
+            parameters.setSaveIntermediates(moduleConfig.getBooleanProperty("save-intermediates", DEFAULT_SAVE_INTERMEDIATES));
+            parameters.setEnableLossesCompensation(moduleConfig.getBooleanProperty("enable-losses-compensation", DEFAULT_ENABLE_LOSSES_COMPENSATION));
+            parameters.setLossesCompensationEpsilon(moduleConfig.getDoubleProperty("losses-compensation-epsilon", DEFAULT_LOSSES_COMPENSATION_EPSILON));
+            parameters.setSensitivityEpsilon(moduleConfig.getDoubleProperty("sensitivity-epsilon", DEFAULT_SENSITIVITY_EPSILON));
+            parameters.setRescaleEnabled(moduleConfig.getBooleanProperty("rescale-enabled", DEFAULT_RESCALE_ENABLED));
+        });
+    }
+
     public FlowDecompositionParameters() {
         this.saveIntermediates = DEFAULT_SAVE_INTERMEDIATES;
         this.enableLossesCompensation = DEFAULT_ENABLE_LOSSES_COMPENSATION;
         this.lossesCompensationEpsilon = DEFAULT_LOSSES_COMPENSATION_EPSILON;
         this.sensitivityEpsilon = DEFAULT_SENSITIVITY_EPSILON;
-        this.rescaleEnabled = DEFAULT_RESCALE_MODE;
+        this.rescaleEnabled = DEFAULT_RESCALE_ENABLED;
     }
 
     public boolean doesSaveIntermediates() {

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionParametersTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionParametersTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.flow_decomposition;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.powsybl.commons.config.InMemoryPlatformConfig;
+import com.powsybl.commons.config.MapModuleConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.FileSystem;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+class FlowDecompositionParametersTests {
+    private static final double EPSILON = 1e-5;
+    private static FileSystem fileSystem;
+    private InMemoryPlatformConfig platformConfig;
+
+    @BeforeAll
+    static void createFileSystem() {
+        fileSystem = Jimfs.newFileSystem(Configuration.unix());
+    }
+
+    @BeforeEach
+    void createInMemoryPlatformConfig() {
+        platformConfig = new InMemoryPlatformConfig(fileSystem);
+    }
+
+    @AfterAll
+    static void closeFileSystem() throws Exception {
+        fileSystem.close();
+    }
+
+    @Test
+    void checkDefaultParameters() {
+        FlowDecompositionParameters parameters = FlowDecompositionParameters.load();
+        assertFalse(parameters.doesSaveIntermediates());
+        assertFalse(parameters.isLossesCompensationEnabled());
+        assertEquals(1e-5, parameters.getLossesCompensationEpsilon(), EPSILON);
+        assertEquals(1e-5, parameters.getSensitivityEpsilon(), EPSILON);
+        assertFalse(parameters.isRescaleEnabled());
+    }
+
+    @Test
+    void checkCompleteConfigurationOfParameters() {
+        MapModuleConfig mapModuleConfig = platformConfig.createModuleConfig("flow-decomposition-default-parameters");
+        mapModuleConfig.setStringProperty("save-intermediates", Boolean.toString(true));
+        mapModuleConfig.setStringProperty("enable-losses-compensation", Boolean.toString(true));
+        mapModuleConfig.setStringProperty("losses-compensation-epsilon", Double.toString(2e-5));
+        mapModuleConfig.setStringProperty("sensitivity-epsilon", Double.toString(3e-3));
+        mapModuleConfig.setStringProperty("rescale-enabled", Boolean.toString(true));
+
+        FlowDecompositionParameters parameters = FlowDecompositionParameters.load(platformConfig);
+        assertTrue(parameters.doesSaveIntermediates());
+        assertTrue(parameters.isLossesCompensationEnabled());
+        assertEquals(2e-5, parameters.getLossesCompensationEpsilon(), EPSILON);
+        assertEquals(3e-3, parameters.getSensitivityEpsilon(), EPSILON);
+        assertTrue(parameters.isRescaleEnabled());
+    }
+
+    @Test
+    void checkIncompleteConfigurationOfParameters() {
+        MapModuleConfig mapModuleConfig = platformConfig.createModuleConfig("flow-decomposition-default-parameters");
+        mapModuleConfig.setStringProperty("save-intermediates", Boolean.toString(true));
+        mapModuleConfig.setStringProperty("losses-compensation-epsilon", Double.toString(2e-5));
+
+        FlowDecompositionParameters parameters = FlowDecompositionParameters.load(platformConfig);
+        assertTrue(parameters.doesSaveIntermediates());
+        assertFalse(parameters.isLossesCompensationEnabled());
+        assertEquals(2e-5, parameters.getLossesCompensationEpsilon(), EPSILON);
+        assertEquals(1e-5, parameters.getSensitivityEpsilon(), EPSILON);
+        assertFalse(parameters.isRescaleEnabled());
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sébastien Murgey <sebastien.murgey@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently it is only possible to specify flow decomposition parameters value using code modification


**What is the new behavior (if this is a feature change)?**
Flow decomposition parameters are now available as a module configuration in powsybl config.yml file.
