### PR TITLE
Fix rescaling

### DIFF
--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlowsRescaler.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlowsRescaler.java
@@ -36,7 +36,7 @@ class DecomposedFlowsRescaler {
         Map<String, Double> loopFlows = decomposedFlow.getLoopFlows();
         double acReferenceFlow = decomposedFlow.getAcReferenceFlow();
         double dcReferenceFlow = decomposedFlow.getDcReferenceFlow();
-        double deltaToRescale = (acReferenceFlow - dcReferenceFlow) * Math.signum(acReferenceFlow);
+        double deltaToRescale = (acReferenceFlow * Math.signum(acReferenceFlow) - decomposedFlow.getTotalFlow());
         double sumOfReLUFlows = reLU(allocatedFlow) + reLU(pstFlow) + loopFlows.values().stream().mapToDouble(this::reLU).sum();
         Map<String, Double> rescaledLoopFlows = loopFlows.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> rescaleValue(entry.getValue(), deltaToRescale, sumOfReLUFlows)));

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlowsRescaler.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlowsRescaler.java
@@ -36,7 +36,7 @@ class DecomposedFlowsRescaler {
         Map<String, Double> loopFlows = decomposedFlow.getLoopFlows();
         double acReferenceFlow = decomposedFlow.getAcReferenceFlow();
         double dcReferenceFlow = decomposedFlow.getDcReferenceFlow();
-        double deltaToRescale = (acReferenceFlow * Math.signum(acReferenceFlow) - decomposedFlow.getTotalFlow());
+        double deltaToRescale = acReferenceFlow * Math.signum(acReferenceFlow) - decomposedFlow.getTotalFlow();
         double sumOfReLUFlows = reLU(allocatedFlow) + reLU(pstFlow) + loopFlows.values().stream().mapToDouble(this::reLU).sum();
         Map<String, Double> rescaledLoopFlows = loopFlows.entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> rescaleValue(entry.getValue(), deltaToRescale, sumOfReLUFlows)));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
- Fix recaling behavior when the reference flows are of different signs.


**What is the current behavior?** *(You can also link to an open issue here)*
Before rescaling, the sum of decomposed flow is different from the DC Reference flow.
After rescaling, the sum of decomposed flow is different from the AC Reference flow.


**What is the new behavior (if this is a feature change)?**
Before rescaling, the sum of decomposed flow is equal to the DC Reference flow (fixed in OLF in 0.22).
After rescaling, the sum of decomposed flow is equal to the AC Reference flow (fixed in the module).


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
Require OLF version change from 0.21 to 0.22

(if any of the questions/checkboxes don't apply, please delete them entirely)
