### PR TITLE
Adding total mismatch in the error message

### DIFF
--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
@@ -114,7 +114,7 @@ public class BalanceComputationImpl implements BalanceComputation {
             LOGGER.info("Areas {} are balanced after {} iterations", networkAreasName, result.getIterationCount());
 
         } else {
-            LOGGER.error("Areas are unbalanced after {} iterations", context.getIterationNum());
+            LOGGER.error("Areas are unbalanced after {} iterations, total mismatch is {}", context.getIterationNum(), String.format("%.2f", computeTotalMismatch(context)));
         }
 
         network.getVariantManager().removeVariant(workingVariantCopyId);

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImpl.java
@@ -16,6 +16,8 @@ import com.powsybl.loadflow.LoadFlowResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -114,7 +116,7 @@ public class BalanceComputationImpl implements BalanceComputation {
             LOGGER.info("Areas {} are balanced after {} iterations", networkAreasName, result.getIterationCount());
 
         } else {
-            LOGGER.error("Areas are unbalanced after {} iterations, total mismatch is {}", context.getIterationNum(), String.format("%.2f", computeTotalMismatch(context)));
+            LOGGER.error("Areas are unbalanced after {} iterations, total mismatch is {}", context.getIterationNum(), BigDecimal.valueOf(computeTotalMismatch(context)).setScale(2, RoundingMode.UP));
         }
 
         network.getVariantManager().removeVariant(workingVariantCopyId);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
In  case of failure, it's useful to have the final mismatch of the balances adjustement in the error message to let the user increase the threshold parameter 

**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
