### PR TITLE
Test EMF using subnetworks (bump core to 6.0.0, open-loadflow to 1.3.0)

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v1
       with:
         repository: powsybl/powsybl-core
-        ref: refs/heads/adapt-cgmes-export-subnetworks
+        ref: refs/heads/adapt-cgmes-export-subnetworks-2
         
     - name: Build and install powsybl-core with Maven
       run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v1
       with:
         repository: powsybl/powsybl-open-loadflow
-        ref: refs/heads/draft_dirty_bump_core_6.0.0
+        ref: refs/heads/main
         
     - name: Build and install powsybl-open-loadflow with Maven
       run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,6 +24,15 @@ jobs:
       with:
         java-version: 11
 
+    - name: Checkout powsybl-core latest sources
+      uses: actions/checkout@v1
+      with:
+        repository: powsybl/powsybl-core
+        ref: refs/heads/adapt-cgmes-export-subnetworks
+        
+    - name: Build and install powsybl-core with Maven
+      run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
+
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'
       run: mvn --batch-mode -Pjacoco install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,15 +25,6 @@ jobs:
       with:
         java-version: 17
 
-    - name: Checkout powsybl-core latest sources
-      uses: actions/checkout@v1
-      with:
-        repository: powsybl/powsybl-core
-        ref: refs/heads/main
-        
-    - name: Build and install powsybl-core with Maven
-      run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
-
     - name: Checkout powsybl-open-loadflow latest sources
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,10 +29,19 @@ jobs:
       uses: actions/checkout@v1
       with:
         repository: powsybl/powsybl-core
-        ref: refs/heads/adapt-cgmes-export-subnetworks-2
+        ref: refs/heads/main
         
     - name: Build and install powsybl-core with Maven
       run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml install
+
+    - name: Checkout powsybl-open-loadflow latest sources
+      uses: actions/checkout@v1
+      with:
+        repository: powsybl/powsybl-open-loadflow
+        ref: refs/heads/main
+        
+    - name: Build and install powsybl-open-loadflow with Maven
+      run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install
 
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,15 +25,6 @@ jobs:
       with:
         java-version: 17
 
-    - name: Checkout powsybl-open-loadflow latest sources
-      uses: actions/checkout@v1
-      with:
-        repository: powsybl/powsybl-open-loadflow
-        ref: refs/heads/main
-        
-    - name: Build and install powsybl-open-loadflow with Maven
-      run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install
-
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'
       run: mvn --batch-mode -Pjacoco install

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v1
       with:
         repository: powsybl/powsybl-open-loadflow
-        ref: refs/heads/main
+        ref: refs/heads/draft_dirty_bump_core_6.0.0
         
     - name: Build and install powsybl-open-loadflow with Maven
       run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml install

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/NetworkAreaUtil.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/NetworkAreaUtil.java
@@ -13,7 +13,6 @@ import com.powsybl.iidm.network.Load;
 import com.powsybl.iidm.network.extensions.LoadDetail;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
@@ -33,14 +32,14 @@ public final class NetworkAreaUtil {
                 .map(t -> (Load) t.getConnectable())
                 .filter(load -> load.getP0() >= 0)
                 .filter(load -> load.getExtension(LoadDetail.class) != null && load.getExtension(LoadDetail.class).getVariableActivePower() != 0)
-                .collect(Collectors.toList());
+                .toList();
         if (loads.isEmpty()) {
             loads = area.getContainedBusViewBuses().stream()
                     .flatMap(Bus::getConnectedTerminalStream)
                     .filter(t -> t.getConnectable() instanceof Load)
                     .map(t -> (Load) t.getConnectable())
                     .filter(load -> load.getP0() >= 0)
-                    .collect(Collectors.toList());
+                    .toList();
             if (loads.isEmpty()) {
                 throw new PowsyblException("There is no load in this area");
             }
@@ -49,8 +48,8 @@ public final class NetworkAreaUtil {
         if (totalP0 == 0.0) {
             throw new PowsyblException("All loads' active power flows is null"); // this case should never happen
         }
-        List<Float> percentages = loads.stream().map(load -> (float) (100f * load.getP0() / totalP0)).collect(Collectors.toList());
-        return Scalable.proportional(percentages, loads.stream().map(inj -> (Scalable) Scalable.onLoad(inj.getId())).collect(Collectors.toList()));
+        List<Double> percentages = loads.stream().map(load -> 100.0 * load.getP0() / totalP0).toList();
+        return Scalable.proportional(percentages, loads.stream().map(inj -> (Scalable) Scalable.onLoad(inj.getId())).toList());
     }
 
     private NetworkAreaUtil() {

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
@@ -57,9 +57,9 @@ class BalanceComputationImplDcTest {
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
 
-        scalableFR = Scalable.proportional(Arrays.asList(60f, 30f, 10f),
+        scalableFR = Scalable.proportional(Arrays.asList(60.0, 30.0, 10.0),
                 Arrays.asList(Scalable.onGenerator("FFR1AA1 _generator"), Scalable.onGenerator("FFR2AA1 _generator"), Scalable.onGenerator("FFR3AA1 _generator")));
-        scalableBE = Scalable.proportional(Arrays.asList(60f, 30f, 10f),
+        scalableBE = Scalable.proportional(Arrays.asList(60.0, 30.0, 10.0),
                 Arrays.asList(Scalable.onGenerator("BBE1AA1 _generator"), Scalable.onGenerator("BBE3AA1 _generator"), Scalable.onGenerator("BBE2AA1 _generator")));
     }
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -65,10 +65,10 @@ class BalanceComputationSimpleDcTest {
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
 
-        scalableFR = Scalable.proportional(Arrays.asList(60f, 40f),
+        scalableFR = Scalable.proportional(Arrays.asList(60.0, 40.0),
                 Arrays.asList(Scalable.onGenerator("GENERATOR_FR"), Scalable.onLoad("LOAD_FR")));
 
-        scalableBE = Scalable.proportional(Arrays.asList(60f, 40f),
+        scalableBE = Scalable.proportional(Arrays.asList(60.0, 40.0),
                 Arrays.asList(Scalable.onGenerator("GENERATOR_BE"), Scalable.onLoad("LOAD_BE")));
 
         generatorFr = simpleNetwork.getGenerator("GENERATOR_FR");

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/extension/ExtendedBalanceComputationTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/extension/ExtendedBalanceComputationTest.java
@@ -57,9 +57,9 @@ class ExtendedBalanceComputationTest {
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));
 
-        scalableFR = Scalable.proportional(Arrays.asList(60f, 30f, 10f),
+        scalableFR = Scalable.proportional(Arrays.asList(60.0, 30.0, 10.0),
                 Arrays.asList(Scalable.onGenerator("FFR1AA1 _generator"), Scalable.onGenerator("FFR2AA1 _generator"), Scalable.onGenerator("FFR3AA1 _generator")));
-        scalableBE = Scalable.proportional(Arrays.asList(60f, 30f, 10f),
+        scalableBE = Scalable.proportional(Arrays.asList(60.0, 30.0, 10.0),
                 Arrays.asList(Scalable.onGenerator("BBE1AA1 _generator"), Scalable.onGenerator("BBE3AA1 _generator"), Scalable.onGenerator("BBE2AA1 _generator")));
 
     }

--- a/balances-adjustment/src/test/resources/balanceComputationParameters.json
+++ b/balances-adjustment/src/test/resources/balanceComputationParameters.json
@@ -23,10 +23,10 @@
     "dcPowerFactor" : 1.0
   },
   "scaling-parameters" : {
-    "version" : "1.0",
+    "version" : "1.1",
     "scalingConvention" : "GENERATOR",
     "constantPowerFactor" : false,
     "reconnect" : false,
-    "iterative" : false
+    "priority" : "ONESHOT"
   }
 }

--- a/balances-adjustment/src/test/resources/balanceComputationParametersWithExtension.json
+++ b/balances-adjustment/src/test/resources/balanceComputationParametersWithExtension.json
@@ -23,11 +23,11 @@
     "dcPowerFactor" : 1.0
   },
   "scaling-parameters" : {
-    "version" : "1.0",
+    "version" : "1.1",
     "scalingConvention" : "GENERATOR",
     "constantPowerFactor" : false,
     "reconnect" : false,
-    "iterative" : false
+    "priority" : "ONESHOT"
   },
   "extensions" : {
     "dummy-extension" : { }

--- a/emf/pom.xml
+++ b/emf/pom.xml
@@ -32,10 +32,6 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-iidm-mergingview</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-cgmes-conformity</artifactId>
         </dependency>
         <dependency>

--- a/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
+++ b/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
@@ -26,10 +26,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.*;
 import java.util.*;
 import java.util.function.Consumer;
 
@@ -200,6 +197,20 @@ class IGMmergeTests {
         // This should be removed when we export tie lines as two separate equipment
         new ReplaceTieLinesByLines().apply(networkBENL);
         compareNetwork(serializedMergedNetwork, networkBENL);
+    }
+
+    @Test
+    void testCompareSubnetworksMergeAgainstAssembled() {
+        Network merged = Network.create("merged",
+                Network.read(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource()),
+                Network.read(CgmesConformity1Catalog.microGridBaseCaseNL().dataSource()));
+        // In merged, reset all p0, q0 values for all paired dangling lines
+        for (DanglingLine dl : merged.getDanglingLines(DanglingLineFilter.PAIRED)) {
+            dl.setP0(0);
+            dl.setQ0(0);
+        }
+        Network assembled = createCGM();
+        compareNetwork(assembled, merged);
     }
 
     private static void validate(Network n, Set<String> branchIds, Set<String> generatorsId, Set<String> voltageLevelIds) {

--- a/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
+++ b/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
@@ -84,6 +84,9 @@ class IGMmergeTests {
         igmBE.merge(igmNL);
         validNetworks.put("Merged", igmBE);
 
+        // Check that we have subnetworks
+        assertEquals(2, igmBE.getSubNetworks().size());
+
         Path destructiveMergeDir = Files.createDirectories(tmpDir.resolve("destructiveMerge"));
         exportNetwork(igmBE, destructiveMergeDir, "BE_NL", validNetworks, Set.of("EQ", "TP", "SSH", "SV"));
 

--- a/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
+++ b/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
@@ -10,11 +10,10 @@ package com.powsybl.emf;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.powsybl.cgmes.conformity.CgmesConformity1Catalog;
-import com.powsybl.cgmes.conversion.export.*;
+import com.powsybl.cgmes.conversion.CgmesExport;
 import com.powsybl.cgmes.model.GridModelReferenceResources;
 import com.powsybl.commons.datasource.GenericReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
-import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.modification.ReplaceTieLinesByLines;
 import com.powsybl.iidm.network.*;
 import com.powsybl.loadflow.LoadFlow;
@@ -22,15 +21,15 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamWriter;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.*;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.*;
-import java.util.function.Consumer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * @author Bertrand Rix <bertrand.rix at artelys.com>
@@ -53,35 +52,25 @@ class IGMmergeTests {
 
     @Test
     void igmsSubnetworksMerge() throws IOException {
-
         Set<String> branchIds = new HashSet<>();
         Set<String> generatorIds = new HashSet<>();
         Set<String> voltageLevelIds = new HashSet<>();
 
         // load two IGMs BE and NL
-        Map<String, Network> validNetworks = new HashMap<>();
         GridModelReferenceResources resBE = CgmesConformity1Catalog.microGridBaseCaseBE();
         Network igmBE = Network.read(resBE.dataSource());
-        String idBE = igmBE.getId();
         igmBE.getBranches().forEach(b -> branchIds.add(b.getId()));
         igmBE.getGenerators().forEach(g -> generatorIds.add(g.getId()));
         igmBE.getVoltageLevels().forEach(v -> voltageLevelIds.add(v.getId()));
 
         GridModelReferenceResources resNL = CgmesConformity1Catalog.microGridBaseCaseNL();
         Network igmNL = Network.read(resNL.dataSource());
-        String idNL = igmNL.getId();
         igmNL.getBranches().forEach(b -> branchIds.add(b.getId()));
         igmNL.getGenerators().forEach(g -> generatorIds.add(g.getId()));
         igmNL.getVoltageLevels().forEach(v -> voltageLevelIds.add(v.getId()));
 
         // merge, serialize and deserialize the network
         Network merged = Network.create("Merged", igmBE, igmNL);
-        Network subnetworkBE = merged.getSubnetwork(idBE);
-        Network subnetworkNL = merged.getSubnetwork(idNL);
-
-        validNetworks.put("Merged", merged);
-        validNetworks.put("BE", subnetworkBE);
-        validNetworks.put("NL", subnetworkNL);
 
         // Check that we have subnetworks
         assertEquals(2, merged.getSubnetworks().size());
@@ -89,7 +78,7 @@ class IGMmergeTests {
         LoadFlow.run(merged);
 
         Path mergedDir = Files.createDirectories(tmpDir.resolve("subnetworksMerge"));
-        exportNetwork(merged, mergedDir, "BE_NL", validNetworks, Set.of("EQ", "TP", "SSH", "SV"));
+        exportNetwork(merged, mergedDir, "BE_NL", Set.of("EQ", "TP", "SSH", "SV"));
 
         // copy the boundary set explicitly it is not serialized and is needed for reimport
         ResourceSet boundaries = CgmesConformity1Catalog.microGridBaseCaseBoundaries();
@@ -150,7 +139,7 @@ class IGMmergeTests {
 
     private Network exportAndLoad(Network network, String dirName, String country) throws IOException {
         Path dir = Files.createDirectories(tmpDir.resolve(dirName));
-        exportNetwork(network, dir, country, Map.of(country, network), Set.of("EQ", "TP", "SSH"));
+        exportNetwork(network, dir, country, Set.of("EQ", "TP", "SSH"));
 
         // copy the boundary set explicitly it is not serialized and is needed for reimport
         ResourceSet boundaries = CgmesConformity1Catalog.microGridBaseCaseBoundaries();
@@ -178,7 +167,7 @@ class IGMmergeTests {
         LoadFlow.run(networkBENL);
 
         Path mergedResourcesDir = Files.createDirectories(tmpDir.resolve("mergedResourcesExport"));
-        exportNetwork(networkBENL, mergedResourcesDir, "BE_NL", Map.of("BENL", networkBENL), Set.of("EQ", "TP", "SSH", "SV"));
+        exportNetwork(networkBENL, mergedResourcesDir, "BE_NL", Set.of("EQ", "TP", "SSH", "SV"));
 
         //Copy the boundary set explicitly it is not serialized and is needed for reimport
         ResourceSet boundaries = CgmesConformity1Catalog.microGridBaseCaseBoundaries();
@@ -219,37 +208,11 @@ class IGMmergeTests {
         voltageLevelIds.forEach(v -> assertNotNull(n.getVoltageLevel(v)));
     }
 
-    private static void exportNetwork(Network network, Path outputDir, String baseName, Map<String, Network> validNetworks, Set<String> profilesToExport) {
+    private static void exportNetwork(Network network, Path outputDir, String baseName, Set<String> profilesToExport) {
         Objects.requireNonNull(network);
-        Path filenameEq = outputDir.resolve(baseName + "_EQ.xml");
-        Path filenameTp = outputDir.resolve(baseName + "_TP.xml");
-        Path filenameSsh = outputDir.resolve(baseName + "_SSH.xml");
-        Path filenameSv = outputDir.resolve(baseName + "_SV.xml");
-        CgmesExportContext context = new CgmesExportContext();
-        context.setScenarioTime(network.getCaseDate());
-        validNetworks.forEach((name, n) -> context.addIidmMappings(n));
-
-        if (profilesToExport.contains("EQ")) {
-            export(filenameEq, writer -> EquipmentExport.write(network, writer, context));
-        }
-        if (profilesToExport.contains("TP")) {
-            export(filenameTp, writer -> TopologyExport.write(network, writer, context));
-        }
-        if (profilesToExport.contains("SSH")) {
-            export(filenameSsh, writer -> SteadyStateHypothesisExport.write(network, writer, context));
-        }
-        if (profilesToExport.contains("SV")) {
-            export(filenameSv, writer -> StateVariablesExport.write(network, writer, context));
-        }
-    }
-
-    private static void export(Path file, Consumer<XMLStreamWriter> outConsumer) {
-        try (OutputStream out = Files.newOutputStream(file)) {
-            XMLStreamWriter writer = XmlUtil.initializeWriter(true, "    ", out);
-            outConsumer.accept(writer);
-        } catch (IOException | XMLStreamException e) {
-            throw new RuntimeException(e);
-        }
+        Properties exportParams = new Properties();
+        exportParams.put(CgmesExport.PROFILES, String.join(",", profilesToExport));
+        network.write("CGMES", exportParams, outputDir.resolve(baseName));
     }
 
     private static void checkDanglingLine(DanglingLine dl1, DanglingLine dl2) {

--- a/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
+++ b/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
@@ -70,7 +70,7 @@ class IGMmergeTests {
         igmNL.getVoltageLevels().forEach(v -> voltageLevelIds.add(v.getId()));
 
         // merge, serialize and deserialize the network
-        Network merged = Network.create("Merged", igmBE, igmNL);
+        Network merged = Network.merge("Merged", igmBE, igmNL);
 
         // Check that we have subnetworks
         assertEquals(2, merged.getSubnetworks().size());
@@ -121,7 +121,7 @@ class IGMmergeTests {
         Network igmNL = Network.read(resNL.dataSource());
 
         // merge, serialize and deserialize the network
-        Network merged = Network.create("Merged", igmBE, igmNL);
+        Network merged = Network.merge("Merged", igmBE, igmNL);
         Network subnetworkBE = merged.getSubnetwork(idBE);
 
         // Check that we have subnetworks
@@ -190,7 +190,7 @@ class IGMmergeTests {
 
     @Test
     void testCompareSubnetworksMergeAgainstAssembled() {
-        Network merged = Network.create("merged",
+        Network merged = Network.merge("merged",
                 Network.read(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource()),
                 Network.read(CgmesConformity1Catalog.microGridBaseCaseNL().dataSource()));
         // In merged, reset all p0, q0 values for all paired dangling lines

--- a/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
+++ b/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
@@ -171,11 +171,11 @@ class IGMmergeTests {
         Network networkBENL = createCGM();
 
         Set<String> branchIds = new HashSet<>();
-        Set<String> generatorsId = new HashSet<>();
+        Set<String> generatorIds = new HashSet<>();
         Set<String> voltageLevelIds = new HashSet<>();
 
         networkBENL.getBranches().forEach(b -> branchIds.add(b.getId()));
-        networkBENL.getGenerators().forEach(g -> generatorsId.add(g.getId()));
+        networkBENL.getGenerators().forEach(g -> generatorIds.add(g.getId()));
         networkBENL.getVoltageLevels().forEach(v -> voltageLevelIds.add(v.getId()));
 
         LoadFlow.run(networkBENL);
@@ -189,7 +189,7 @@ class IGMmergeTests {
             Files.copy(boundaries.newInputStream(bFile), mergedResourcesDir.resolve("BE_NL" + bFile), StandardCopyOption.REPLACE_EXISTING);
         }
         Network serializedMergedNetwork = Network.read(new GenericReadOnlyDataSource(mergedResourcesDir, "BE_NL"), null);
-        validate(serializedMergedNetwork, branchIds, generatorsId, voltageLevelIds);
+        validate(serializedMergedNetwork, branchIds, generatorIds, voltageLevelIds);
 
         // compare
         // FIXME(Luma) CGMES Export: tie lines as two separate equipment instead of a single ACLS
@@ -200,22 +200,6 @@ class IGMmergeTests {
         // This should be removed when we export tie lines as two separate equipment
         new ReplaceTieLinesByLines().apply(networkBENL);
         compareNetwork(serializedMergedNetwork, networkBENL);
-    }
-
-    private static void resetDanglingLinesP0Q0(Network network) {
-        // FIXME(Luma) CGMES Importer: consider keeping p0, q0 also for assembled (CGM) imports
-        // Adaptations to be able to compare assembled and merged networks
-        // If a dangling line is paired (is part of a tie line)
-        // we should not use p0, q0 anymore,
-        // so it doesn't matter what values they have
-        // Tie lines from CGM do not have p0, q0 set,
-        // and Tie lines from merged networks keep their original p0, q0 values
-        network.getTieLineStream().forEach(tl -> {
-            tl.getDanglingLine1().setP0(0);
-            tl.getDanglingLine1().setQ0(0);
-            tl.getDanglingLine2().setP0(0);
-            tl.getDanglingLine2().setQ0(0);
-        });
     }
 
     private static void validate(Network n, Set<String> branchIds, Set<String> generatorsId, Set<String> voltageLevelIds) {

--- a/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsArea.java
+++ b/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsArea.java
@@ -22,7 +22,7 @@ class CgmesVoltageLevelsArea implements NetworkArea {
     private final List<String> voltageLevelIds = new ArrayList<>();
 
     private final List<DanglingLine> danglingLineBordersCache; // paired and unpaired.
-    private final List<Branch<?>> branchBordersCache; // other branches.
+    private final List<? extends Branch<?>> branchBordersCache; // other branches.
 
     private final Set<Bus> busesCache;
 
@@ -51,14 +51,14 @@ class CgmesVoltageLevelsArea implements NetworkArea {
                 })
                 .filter(dl -> {
                     if (excludedXnodes != null) {
-                        return excludedXnodes.stream().noneMatch(xnodeCode -> dl.getUcteXnodeCode().equals(xnodeCode)); // There is the possibility to exclude dangling lines associated with boundary nodes with given X-node codes
+                        return excludedXnodes.stream().noneMatch(xnodeCode -> dl.getPairingKey().equals(xnodeCode)); // There is the possibility to exclude dangling lines associated with boundary nodes with given X-node codes
                     }
                     return true;
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
-    private List<Branch<?>> createBranchesCache(Network network, CgmesControlArea area) {
+    private List<? extends Branch<?>> createBranchesCache(Network network, CgmesControlArea area) {
         return network.getLineStream()
                 .filter(this::isAreaBorder)
                 .filter(b -> b.getTerminal1().getBusView().getBus() != null && b.getTerminal1().getBusView().getBus().isInMainSynchronousComponent()
@@ -70,7 +70,7 @@ class CgmesVoltageLevelsArea implements NetworkArea {
                     }
                     return true;
                 })
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/Util.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/Util.java
@@ -33,7 +33,7 @@ public final class Util {
 
     public static String findDanglingLineIdForXndoe(Network network, String xnode) {
         Set<String> danglingLines = network.getDanglingLineStream()
-            .filter(dl -> dl.getUcteXnodeCode().equals(xnode))
+            .filter(dl -> dl.getPairingKey().equals(xnode))
             .map(Identifiable::getId)
             .collect(Collectors.toSet());
         if (danglingLines.size() != 1) {

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 /**
  * Convert a single GlskPoint to Scalable
@@ -48,7 +47,7 @@ public final class GlskPointScalableConverter {
 
     public static Scalable convert(Network network, List<GlskShiftKey> shiftKeys) {
         Objects.requireNonNull(shiftKeys);
-        List<Float> percentages = new ArrayList<>();
+        List<Double> percentages = new ArrayList<>();
         List<Scalable> scalables = new ArrayList<>();
 
         for (GlskShiftKey glskShiftKey : shiftKeys) {
@@ -71,27 +70,27 @@ public final class GlskPointScalableConverter {
         return Scalable.proportional(percentages, scalables); // iterative must be set in scalingParameters during scale
     }
 
-    private static void convertRemainingCapacity(Network network, GlskShiftKey glskShiftKey, List<Float> percentages, List<Scalable> scalables) {
+    private static void convertRemainingCapacity(Network network, GlskShiftKey glskShiftKey, List<Double> percentages, List<Scalable> scalables) {
         LOGGER.debug("GLSK Type B44, not empty registered resources list --> remaining capacity proportional GSK");
         // Remaining capacity algorithm is supposed to put all generators at Pmin at the same time when decreasing
         // generation, and to put all generators at Pmax at the same time when increasing generation.
         // Though the scaling is not symmetrical.
         List<GlskRegisteredResource> generatorResources = glskShiftKey.getRegisteredResourceArrayList().stream()
                 .filter(generatorResource -> NetworkUtil.isCorrect(network.getGenerator(generatorResource.getGeneratorId())))
-                .collect(Collectors.toList());
+                .toList();
 
         Scalable upScalable = createRemainingCapacityScalable(network, glskShiftKey, generatorResources, GlskPointScalableConverter::getRemainingCapacityUp);
         Scalable downScalable = createRemainingCapacityScalable(network, glskShiftKey, generatorResources, GlskPointScalableConverter::getRemainingCapacityDown);
-        percentages.add(100.f);
+        percentages.add(100.0);
         scalables.add(Scalable.upDown(upScalable, downScalable));
     }
 
     private static Scalable createRemainingCapacityScalable(Network network, GlskShiftKey glskShiftKey, List<GlskRegisteredResource> generatorResources, BiFunction<GlskRegisteredResource, Network, Double> remainingCapacityFunction) {
-        List<Float> percentages = new ArrayList<>();
+        List<Double> percentages = new ArrayList<>();
         List<Scalable> scalables = new ArrayList<>();
         double totalFactor = generatorResources.stream().mapToDouble(resource -> remainingCapacityFunction.apply(resource, network)).sum();
         generatorResources.forEach(generatorResource -> {
-            float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor);
+            double generatorPercentage = 100.0 * glskShiftKey.getQuantity() * remainingCapacityFunction.apply(generatorResource, network) / totalFactor;
             if (!Double.isNaN(generatorPercentage)) {
                 percentages.add(generatorPercentage);
                 scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
@@ -146,7 +145,7 @@ public final class GlskPointScalableConverter {
      * @param percentages list of percentage factor of scalable
      * @param scalables list of scalable
      */
-    private static void convertCountryProportional(Network network, GlskShiftKey glskShiftKey, List<Float> percentages, List<Scalable> scalables) {
+    private static void convertCountryProportional(Network network, GlskShiftKey glskShiftKey, List<Double> percentages, List<Scalable> scalables) {
         Country country = new CountryEICode(glskShiftKey.getSubjectDomainmRID()).getCountry();
 
         if (glskShiftKey.getPsrType().equals("A04")) {
@@ -154,12 +153,12 @@ public final class GlskPointScalableConverter {
             List<Generator> generators = network.getGeneratorStream()
                     .filter(generator -> country.equals(getSubstationNullableCountry(generator.getTerminal().getVoltageLevel().getSubstation())))
                     .filter(NetworkUtil::isCorrect)
-                    .collect(Collectors.toList());
+                    .toList();
             //calculate sum P of country's generators
             double totalCountryP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
             //calculate factor of each generator
             generators.forEach(generator -> {
-                float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoTargetP(generator) / totalCountryP);
+                double generatorPercentage = 100.0 * glskShiftKey.getQuantity() * NetworkUtil.pseudoTargetP(generator) / totalCountryP;
                 percentages.add(generatorPercentage);
                 scalables.add(Scalable.onGenerator(generator.getId()));
             });
@@ -168,12 +167,12 @@ public final class GlskPointScalableConverter {
             List<Load> loads = network.getLoadStream()
                     .filter(load -> country.equals(getSubstationNullableCountry(load.getTerminal().getVoltageLevel().getSubstation())))
                     .filter(NetworkUtil::isCorrect)
-                    .collect(Collectors.toList());
+                    .toList();
 
             //calculate sum P of country's loads
             double totalCountryP = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
             loads.forEach(load -> {
-                float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoP0(load) / totalCountryP);
+                double loadPercentage = 100.0 * glskShiftKey.getQuantity() * NetworkUtil.pseudoP0(load) / totalCountryP;
                 percentages.add(loadPercentage);
                 scalables.add(Scalable.onLoad(load.getId(), -Double.MAX_VALUE, Double.MAX_VALUE));
             });
@@ -187,7 +186,7 @@ public final class GlskPointScalableConverter {
      * @param percentages list of percentage factor of scalable
      * @param scalables list of scalable
      */
-    private static void convertExplicitProportional(Network network, GlskShiftKey glskShiftKey, List<Float> percentages, List<Scalable> scalables) {
+    private static void convertExplicitProportional(Network network, GlskShiftKey glskShiftKey, List<Double> percentages, List<Scalable> scalables) {
         if (glskShiftKey.getPsrType().equals("A04")) {
             LOGGER.debug("GLSK Type B42, not empty registered resources list --> (explicit/manual) proportional GSK");
 
@@ -195,13 +194,13 @@ public final class GlskPointScalableConverter {
                     .map(GlskRegisteredResource::getGeneratorId)
                     .map(network::getGenerator)
                     .filter(NetworkUtil::isCorrect)
-                    .collect(Collectors.toList());
+                    .toList();
             double totalP = generators.stream().mapToDouble(NetworkUtil::pseudoTargetP).sum();
 
             generators.forEach(generator -> {
                 // Calculate factor of each generator
                 float factor = (float) (glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoTargetP(generator) / totalP);
-                percentages.add(100 * factor);
+                percentages.add(100.0 * factor);
                 // In case of global shift key limitation we will limit the generator proportionally to
                 // its participation in the global proportional scalable
                 double maxGeneratorValue = NetworkUtil.pseudoTargetP(generator) + factor * glskShiftKey.getMaximumShift();
@@ -213,11 +212,11 @@ public final class GlskPointScalableConverter {
                     .map(GlskRegisteredResource::getLoadId)
                     .map(network::getLoad)
                     .filter(NetworkUtil::isCorrect)
-                    .collect(Collectors.toList());
+                    .toList();
             double totalP = loads.stream().mapToDouble(NetworkUtil::pseudoP0).sum();
 
             loads.forEach(load -> {
-                float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * NetworkUtil.pseudoP0(load) / totalP);
+                double loadPercentage = 100.0 * glskShiftKey.getQuantity() * NetworkUtil.pseudoP0(load) / totalP;
                 // For now glsk shift key maximum shift is not handled for loads by lack of specification
                 percentages.add(loadPercentage);
                 scalables.add(Scalable.onLoad(load.getId(), -Double.MAX_VALUE, Double.MAX_VALUE));
@@ -232,18 +231,18 @@ public final class GlskPointScalableConverter {
      * @param percentages list of percentage factor of scalable
      * @param scalables list of scalable
      */
-    private static void convertParticipationFactor(Network network, GlskShiftKey glskShiftKey, List<Float> percentages, List<Scalable> scalables) {
+    private static void convertParticipationFactor(Network network, GlskShiftKey glskShiftKey, List<Double> percentages, List<Scalable> scalables) {
         if (glskShiftKey.getPsrType().equals("A04")) {
             LOGGER.debug("GLSK Type B43 GSK");
 
             List<GlskRegisteredResource> generatorResources = glskShiftKey.getRegisteredResourceArrayList().stream()
                     .filter(generatorResource -> NetworkUtil.isCorrect(network.getGenerator(generatorResource.getGeneratorId())))
-                    .collect(Collectors.toList());
+                    .toList();
 
             double totalFactor = generatorResources.stream().mapToDouble(GlskRegisteredResource::getParticipationFactor).sum();
 
             generatorResources.forEach(generatorResource -> {
-                float generatorPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * generatorResource.getParticipationFactor() / totalFactor);
+                double generatorPercentage = 100.0 * glskShiftKey.getQuantity() * generatorResource.getParticipationFactor() / totalFactor;
                 percentages.add(generatorPercentage);
                 scalables.add(getGeneratorScalableWithLimits(network, generatorResource));
             });
@@ -251,12 +250,12 @@ public final class GlskPointScalableConverter {
             LOGGER.debug("GLSK Type B43 LSK");
             List<GlskRegisteredResource> loadResources = glskShiftKey.getRegisteredResourceArrayList().stream()
                     .filter(loadResource -> NetworkUtil.isCorrect(network.getLoad(loadResource.getLoadId())))
-                    .collect(Collectors.toList());
+                    .toList();
 
             double totalFactor = loadResources.stream().mapToDouble(GlskRegisteredResource::getParticipationFactor).sum();
 
             loadResources.forEach(loadResource -> {
-                float loadPercentage = (float) (100 * glskShiftKey.getQuantity().floatValue() * loadResource.getParticipationFactor() / totalFactor);
+                double loadPercentage = 100.0 * glskShiftKey.getQuantity() * loadResource.getParticipationFactor() / totalFactor;
                 percentages.add(loadPercentage);
                 scalables.add(getLoadScalableWithLimits(network, loadResource));
             });

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
 
     <properties>
         <java.version>11</java.version>
-        <powsyblcore.version>5.3.0</powsyblcore.version>
+        <powsyblcore.version>5.4.0-SNAPSHOT</powsyblcore.version>
         <powsyblopenloadflow.version>1.2.0</powsyblopenloadflow.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsyblcore.version>6.0.0-RC1</powsyblcore.version>
-        <powsyblopenloadflow.version>1.3.0-SNAPSHOT</powsyblopenloadflow.version>
+        <powsyblcore.version>6.0.0</powsyblcore.version>
+        <powsyblopenloadflow.version>1.3.0</powsyblopenloadflow.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,
             ../../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>13</version>
+        <version>15</version>
         <relativePath />
     </parent>
 
@@ -58,7 +58,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsyblcore.version>6.0.0-SNAPSHOT</powsyblcore.version>
+        <powsyblcore.version>6.0.0-RC1</powsyblcore.version>
         <powsyblopenloadflow.version>1.3.0-SNAPSHOT</powsyblopenloadflow.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <properties>
         <java.version>17</java.version>
         <powsyblcore.version>6.0.0-SNAPSHOT</powsyblcore.version>
-        <powsyblopenloadflow.version>1.2.3</powsyblopenloadflow.version>
+        <powsyblopenloadflow.version>1.3.0-SNAPSHOT</powsyblopenloadflow.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,
             ../../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In 5.3.0 of powsybl-core the Network::merge was implemented as "destructive": objects from the merged network were moved to the destination network.


**What is the new behavior (if this is a feature change)?**
We use core 6.0.0-RC1, that contains an implementation of merge using subnetworks.

This PR also contains other changes required for the core bump to 6.0.0. 
For open load flow we use a specific branch that contains a non-official upgrade of OLF to core 6.0.0.

```diff
- The temporary references to 6.0.0-RC1 of core and snapshot build of OLF must be updated before merging this PR. 
- Once the releases of core and olf are published, the updates in maven.yml in .github/workflows can be discarded.
```

**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
