### PR TITLE
Fix incorrect computation of exchanges between CountryArea instances when a TieLine was connecting them.

### DIFF
--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/CountryArea.java
@@ -64,8 +64,8 @@ public class CountryArea implements NetworkArea {
         return Collections.unmodifiableCollection(busesCache);
     }
 
-    public double getLeavingFlowToCountry(CountryArea countryArea) {
-        countryArea.getCountries().forEach(country -> {
+    public double getLeavingFlowToCountry(CountryArea otherCountryArea) {
+        otherCountryArea.getCountries().forEach(country -> {
             if (countries.contains(country)) {
                 throw new PowsyblException("The leaving flow to the country area cannot be computed. " +
                         "The country " + country.getName() + " is contained in both control areas.");
@@ -73,17 +73,17 @@ public class CountryArea implements NetworkArea {
         });
         double sum = 0;
         for (DanglingLine danglingLine : danglingLineBordersCache) {
-            if (otherSideIsInArea(danglingLine, countryArea)) {
+            if (otherSideIsInArea(danglingLine, otherCountryArea)) {
                 sum += getLeavingFlow(danglingLine);
             }
         }
         for (Line line : lineBordersCache) {
-            if (countryArea.isAreaBorder(line)) {
+            if (otherCountryArea.isAreaBorder(line)) {
                 sum += getLeavingFlow(line);
             }
         }
         for (HvdcLine line : hvdcLineBordersCache) {
-            if (countryArea.isAreaBorder(line)) {
+            if (otherCountryArea.isAreaBorder(line)) {
                 sum += getLeavingFlow(line);
             }
         }

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/CountryAreaTest.java
@@ -26,21 +26,22 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 class CountryAreaTest {
 
+    private static final double EPSILON = 1;
     private Network testNetwork1;
     private Network testNetwork2;
 
-    private CountryAreaFactory countryAreaFR;
-    private CountryAreaFactory countryAreaES;
-    private CountryAreaFactory countryAreaBE;
+    private CountryAreaFactory countryAreaFactoryFR;
+    private CountryAreaFactory countryAreaFactoryES;
+    private CountryAreaFactory countryAreaFactoryBE;
 
     @BeforeEach
     void setUp() {
         testNetwork1 = Network.read("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
         testNetwork2 = NetworkTestFactory.createNetwork();
 
-        countryAreaFR = new CountryAreaFactory(Country.FR);
-        countryAreaES = new CountryAreaFactory(Country.ES);
-        countryAreaBE = new CountryAreaFactory(Country.BE);
+        countryAreaFactoryFR = new CountryAreaFactory(Country.FR);
+        countryAreaFactoryES = new CountryAreaFactory(Country.ES);
+        countryAreaFactoryBE = new CountryAreaFactory(Country.BE);
     }
 
     private Stream<Injection> getInjectionStream(Network network) {
@@ -65,29 +66,29 @@ class CountryAreaTest {
     @Test
     void testGetNetPosition() {
         //Test network with BranchBorder
-        assertEquals(0, countryAreaES.create(testNetwork1).getNetPosition(), 1e-3);
+        assertEquals(0, countryAreaFactoryES.create(testNetwork1).getNetPosition(), 1e-3);
 
-        assertEquals(-getSumFlowCountry(testNetwork1, Country.FR), countryAreaFR.create(testNetwork1).getNetPosition(), 1e-3);
+        assertEquals(-getSumFlowCountry(testNetwork1, Country.FR), countryAreaFactoryFR.create(testNetwork1).getNetPosition(), 1e-3);
 
         //Test network with HVDCLines
-        assertEquals(testNetwork2.getHvdcLine("hvdcLineFrEs").getConverterStation1().getTerminal().getP(), countryAreaFR.create(testNetwork2).getNetPosition(), 1e-3);
-        assertEquals(testNetwork2.getHvdcLine("hvdcLineFrEs").getConverterStation2().getTerminal().getP(), countryAreaES.create(testNetwork2).getNetPosition(), 1e-3);
+        assertEquals(testNetwork2.getHvdcLine("hvdcLineFrEs").getConverterStation1().getTerminal().getP(), countryAreaFactoryFR.create(testNetwork2).getNetPosition(), 1e-3);
+        assertEquals(testNetwork2.getHvdcLine("hvdcLineFrEs").getConverterStation2().getTerminal().getP(), countryAreaFactoryES.create(testNetwork2).getNetPosition(), 1e-3);
     }
 
     @Test
     void testSpecialDevices() {
         Network network = Network.read("testCaseSpecialDevices.xiidm", getClass().getResourceAsStream("/testCaseSpecialDevices.xiidm"));
-        assertEquals(100, countryAreaFR.create(network).getNetPosition(), 1e-3);
-        assertEquals(-100, countryAreaES.create(network).getNetPosition(), 1e-3);
+        assertEquals(100, countryAreaFactoryFR.create(network).getNetPosition(), 1e-3);
+        assertEquals(-100, countryAreaFactoryES.create(network).getNetPosition(), 1e-3);
     }
 
     @Test
     void testGetLeavingFlowToCountry() {
-        CountryArea countryAreaFR2 = countryAreaFR.create(testNetwork2);
-        CountryArea countryAreaES2 = countryAreaES.create(testNetwork2);
-        CountryArea countryAreaFR1 = countryAreaFR.create(testNetwork1);
-        CountryArea countryAreaBE1 = countryAreaBE.create(testNetwork1);
-        CountryArea countryAreaES1 = countryAreaES.create(testNetwork1);
+        CountryArea countryAreaFR2 = countryAreaFactoryFR.create(testNetwork2);
+        CountryArea countryAreaES2 = countryAreaFactoryES.create(testNetwork2);
+        CountryArea countryAreaFR1 = countryAreaFactoryFR.create(testNetwork1);
+        CountryArea countryAreaBE1 = countryAreaFactoryBE.create(testNetwork1);
+        CountryArea countryAreaES1 = countryAreaFactoryES.create(testNetwork1);
 
         assertEquals(100.0, countryAreaFR2.getLeavingFlowToCountry(countryAreaES2), 1e-3);
         assertEquals(-100.0, countryAreaES2.getLeavingFlowToCountry(countryAreaFR2), 1e-3);
@@ -95,7 +96,7 @@ class CountryAreaTest {
         assertEquals(324.666, countryAreaBE1.getLeavingFlowToCountry(countryAreaFR1), 1e-3);
         assertEquals(0.0, countryAreaBE1.getLeavingFlowToCountry(countryAreaES1), 1e-3);
         try {
-            countryAreaFR.create(testNetwork1).getLeavingFlowToCountry(countryAreaFR1);
+            countryAreaFR1.getLeavingFlowToCountry(countryAreaFR1);
             fail();
         } catch (PowsyblException e) {
             assertEquals("The leaving flow to the country area cannot be computed. The country FRANCE is contained in both control areas.", e.getMessage());
@@ -105,7 +106,27 @@ class CountryAreaTest {
     @Test
     void testWithTieLine() {
         Network network = Network.read("controlArea.xiidm", getClass().getResourceAsStream("/controlArea.xiidm"));
-        countryAreaBE = new CountryAreaFactory(Country.BE);
-        assertEquals(-261.858, countryAreaBE.create(network).getNetPosition(), 1e-3);
+        CountryArea countryAreaBE = countryAreaFactoryBE.create(network);
+        assertEquals(-261.858, countryAreaBE.getNetPosition(), 1e-3);
+    }
+
+    @Test
+    void testLeavingFlowToCountryWithTieLines() {
+        Network network = Network.read("border_exchanges.xiidm", getClass().getResourceAsStream("/border_exchanges.xiidm"));
+
+        CountryArea countryAreaIT = new CountryAreaFactory(Country.IT).create(network);
+        CountryArea countryAreaCH = new CountryAreaFactory(Country.CH).create(network);
+        CountryArea countryAreaDE = new CountryAreaFactory(Country.DE).create(network);
+        CountryArea countryAreaFR = new CountryAreaFactory(Country.FR).create(network);
+        CountryArea countryAreaSI = new CountryAreaFactory(Country.SI).create(network);
+        CountryArea countryAreaAT = new CountryAreaFactory(Country.AT).create(network);
+
+        assertEquals(0, countryAreaIT.getLeavingFlowToCountry(countryAreaSI), EPSILON);
+        assertEquals(-2837, countryAreaIT.getLeavingFlowToCountry(countryAreaCH), EPSILON);
+        assertEquals(0, countryAreaFR.getLeavingFlowToCountry(countryAreaDE), EPSILON);
+        assertEquals(-2463, countryAreaIT.getLeavingFlowToCountry(countryAreaFR), EPSILON);
+        assertEquals(-37, countryAreaCH.getLeavingFlowToCountry(countryAreaFR), EPSILON);
+        assertEquals(0, countryAreaCH.getLeavingFlowToCountry(countryAreaDE), EPSILON);
+        assertEquals(-699, countryAreaIT.getLeavingFlowToCountry(countryAreaAT), EPSILON);
     }
 }

--- a/balances-adjustment/src/test/resources/border_exchanges.xiidm
+++ b/balances-adjustment/src/test/resources/border_exchanges.xiidm
@@ -1,0 +1,401 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_10" id="20210901_2230_test_network" caseDate="2021-09-01T22:30:00.000+02:00" forecastDistance="0" sourceFormat="UCTE" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="OUSTR1" country="AT">
+        <iidm:voltageLevel id="OUSTR11" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="OUSTR111" v="400.0" angle="3.392171058546682">
+                    <iidm:property name="geographicalName" value="AT1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="OUSTR111_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="200.0" targetV="400.0" targetQ="0.0" bus="OUSTR111" connectableBus="OUSTR111" p="-200.0" q="-1.7362240966343434">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="OUSTR2" country="AT">
+        <iidm:voltageLevel id="OUSTR21" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="OUSTR211" v="400.0" angle="3.511542187072921">
+                    <iidm:property name="geographicalName" value="AT2"/>
+                </iidm:bus>
+                <iidm:bus id="OUSTR311" v="400.0" angle="2.556573158579824">
+                    <iidm:property name="geographicalName" value="AT3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="OUSTR211_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="300.0" targetV="400.0" targetQ="0.0" bus="OUSTR211" connectableBus="OUSTR211" p="-300.0" q="-2.257079086453024">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="OUSTR311_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="200.0" targetV="400.0" targetQ="0.0" bus="OUSTR311" connectableBus="OUSTR311" p="-200.0" q="-34.60767974682037">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:danglingLine id="XAUSTR11 OUSTR311 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XAUSTR11" bus="OUSTR311" connectableBus="OUSTR311" p="699.9998072332442" q="30.683826709255417">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="OUSTR211 OUSTR311 1" r="0.0" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="OUSTR311" connectableBus1="OUSTR311" voltageLevelId1="OUSTR21" bus2="OUSTR211" connectableBus2="OUSTR211" voltageLevelId2="OUSTR21" p1="-266.66531379387646" q1="2.2223540136918163" p2="266.66531379387646" q2="2.2223540136918163">
+            <iidm:property name="nomimalPower" value="1000.0"/>
+            <iidm:property name="elementName" value="PST"/>
+            <iidm:phaseTapChanger lowTapPosition="-16" tapPosition="0" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.2276423729910535"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.839110508104064"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.4504442277066305"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.061652408895631"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.672743946063913"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.283727749689918"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.894612745121778"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.505407871356285"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.1161220798131644"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.7267643331050597"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.337343603803646"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.9478688732023104"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.5583491300758083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.1687933694373345"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.7792105912934298"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.3896097993971608"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.3896097993971608"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.7792105912934298"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.1687933694373345"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.5583491300758083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.9478688732023104"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.337343603803646"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.7267643331050597"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.1161220798131644"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.505407871356285"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.894612745121778"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.283727749689918"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.672743946063913"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.061652408895631"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.4504442277066305"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.839110508104064"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.2276423729910535"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="5000.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="SWISS1" country="CH">
+        <iidm:voltageLevel id="SWISS11" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SWISS111" v="400.0" angle="21.24862483885987">
+                    <iidm:property name="geographicalName" value="CH1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="SWISS111_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="400.0" targetQ="0.0" bus="SWISS111" connectableBus="SWISS111" p="-1000.0" q="-23.10574294551471">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="SWISS13" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SWISS131">
+                    <iidm:property name="geographicalName" value="CH4"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="SWISS131_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="0.0" bus="SWISS131" connectableBus="SWISS131">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="SWISS2" country="CH">
+        <iidm:voltageLevel id="SWISS21" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SWISS211" v="400.0" angle="18.21911975283224">
+                    <iidm:property name="geographicalName" value="CH2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="SWISS211_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="400.0" targetQ="0.0" bus="SWISS211" connectableBus="SWISS211" p="-1000.0" q="-450.22890639002424">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:danglingLine id="SWISS211 XSWISS11 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XSWISS11" bus="SWISS211" connectableBus="SWISS211" p="2536.979988311214" q="412.9233206123157">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="SWISS3" country="CH">
+        <iidm:voltageLevel id="SWISS31" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SWISS311" v="400.0" angle="20.695724012974182">
+                    <iidm:property name="geographicalName" value="CH3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="SWISS311_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="0.0" bus="SWISS311" connectableBus="SWISS311" p="-500.0" q="-15.732522654400924">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="SMENDR" country="CH">
+        <iidm:voltageLevel id="SMENDR3" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SMENDR32">
+                    <iidm:property name="geographicalName" value="150MENDRISI2"/>
+                </iidm:bus>
+                <iidm:bus id="SMENDR3T" fictitious="true">
+                    <iidm:property name="geographicalName" value="150MENDRISIT"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="SMENDR3T SMENDR32 1" r="0.0538" x="3.485" g="0.0" b="0.0" ratedU1="155.0" ratedU2="155.0" bus1="SMENDR32" connectableBus1="SMENDR32" voltageLevelId1="SMENDR3" bus2="SMENDR3T" connectableBus2="SMENDR3T" voltageLevelId2="SMENDR3">
+            <iidm:property name="nomimalPower" value="400.0"/>
+            <iidm:property name="elementName" value="1_T3MM3104_X"/>
+            <iidm:phaseTapChanger lowTapPosition="-17" tapPosition="-9" targetDeadband="0.0" regulationMode="ACTIVE_POWER_CONTROL" regulationValue="1.0" regulating="false">
+                <iidm:terminalRef id="SMENDR3T SMENDR32 1" side="ONE"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9140639174470565" alpha="-23.926861243830494"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9227708611449534" alpha="-22.66541524583662"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9311809419944868" alpha="-21.38034312086485"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9392602657087807" alpha="-20.072303513023996"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9469745841339483" alpha="-18.742074457135832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.95428960531237" alpha="-17.390556154170262"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9611713341658803" alpha="-16.01877246312593"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9675864394189913" alpha="-14.627870949377595"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9735026410055004" alpha="-13.219121349729267"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9788891108744739" alpha="-11.793912342329133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9837168789117076" alpha="-10.35374654499168"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9879592347025247" alpha="-8.900233707625453"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9915921151613357" alpha="-7.435082112170383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.994594467714281" alpha="-5.960088245003338"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9969485787991699" alpha="-4.477124860043988"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9986403579751515" alpha="-2.9881276033321544"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9996595689189223" alpha="-1.49508041902872"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9996595689189223" alpha="1.49508041902872"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9986403579751515" alpha="2.9881276033321544"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9969485787991699" alpha="4.477124860043988"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.994594467714281" alpha="5.960088245003338"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9915921151613357" alpha="7.435082112170383"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9879592347025247" alpha="8.900233707625453"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9837168789117076" alpha="10.35374654499168"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9788891108744739" alpha="11.793912342329133"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9735026410055004" alpha="13.219121349729267"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9675864394189913" alpha="14.627870949377595"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9611713341658803" alpha="16.01877246312593"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.95428960531237" alpha="17.390556154170262"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9469745841339483" alpha="18.742074457135832"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9392602657087807" alpha="20.072303513023996"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9311809419944868" alpha="21.38034312086485"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9227708611449534" alpha="22.66541524583662"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.9140639174470565" alpha="23.926861243830494"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="1490.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FRANC1" country="FR">
+        <iidm:voltageLevel id="FRANC11" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRANC111" v="400.0" angle="17.931272208968796">
+                    <iidm:property name="geographicalName" value="FR1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRANC111_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="400.0" targetQ="0.0" bus="FRANC111" connectableBus="FRANC111" p="-1000.0" q="-422.4221747912643">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:danglingLine id="FRANC111 XFRANC11 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XFRANC11" bus="FRANC111" connectableBus="FRANC111" p="2463.0076406710514" q="388.5879521605159">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRANC2" country="FR">
+        <iidm:voltageLevel id="FRANC21" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRANC211" v="400.0" angle="20.82817206844942">
+                    <iidm:property name="geographicalName" value="FR2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRANC211_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="400.0" targetQ="0.0" bus="FRANC211" connectableBus="FRANC211" p="-1000.0" q="-21.234170004600188">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FRANC3" country="FR">
+        <iidm:voltageLevel id="FRANC31" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FRANC311" v="400.0" angle="20.27529123790752">
+                    <iidm:property name="geographicalName" value="FR3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FRANC311_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="0.0" bus="FRANC311" connectableBus="FRANC311" p="-500.0" q="-14.132624686211376">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ITALY1" country="IT">
+        <iidm:voltageLevel id="ITALY11" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ITALY111" v="400.0" angle="0.0">
+                    <iidm:property name="geographicalName" value="IT1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ITALY111_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="400.0" targetQ="0.0" bus="ITALY111" connectableBus="ITALY111" p="-0.0" q="-409.1762228953063">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ITALY111_load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="ITALY111" connectableBus="ITALY111" p="2000.0" q="0.0"/>
+            <iidm:danglingLine id="XSLOVE11 ITALY111 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XSLOVE11" bus="ITALY111" connectableBus="ITALY111" p="-299.99998454453174" q="5.626978350752672">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+            <iidm:danglingLine id="XFRANC11 ITALY111 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XFRANC11" bus="ITALY111" connectableBus="ITALY111" p="-2463.0076406710514" q="388.5879521605159">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ITALY2" country="IT">
+        <iidm:voltageLevel id="ITALY21" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ITALY211" v="400.0" angle="-2.463225587192485">
+                    <iidm:property name="geographicalName" value="IT2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ITALY211_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="400.0" targetQ="0.0" bus="ITALY211" connectableBus="ITALY211" p="-0.0" q="-57.18979513445495">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ITALY211_load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="ITALY211" connectableBus="ITALY211" p="2000.0" q="0.0"/>
+            <iidm:danglingLine id="ITALY211 XAUSTR11 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XAUSTR11" bus="ITALY211" connectableBus="ITALY211" p="-699.9998072332442" q="30.683826709255417">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="ITALY3" country="IT">
+        <iidm:voltageLevel id="ITALY31" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="ITALY311" v="400.0" angle="-0.2698749942934311">
+                    <iidm:property name="geographicalName" value="IT3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="ITALY311_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="400.0" targetQ="0.0" bus="ITALY311" connectableBus="ITALY311" p="-0.0" q="-424.8229728299532">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="ITALY311_load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="ITALY311" connectableBus="ITALY311" p="2000.0" q="0.0"/>
+            <iidm:danglingLine id="XSWISS11 ITALY311 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XSWISS11" bus="ITALY311" connectableBus="ITALY311" p="-2536.979988311214" q="412.9233206123157">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="SLOVE1" country="CH">
+        <iidm:voltageLevel id="SLOVE11" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SLOVE111" v="400.0" angle="3.223454325067683">
+                    <iidm:property name="geographicalName" value="SI1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="SLOVE111_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="300.0" targetV="400.0" targetQ="0.0" bus="SLOVE111" connectableBus="SLOVE111" p="-300.0" q="-2.8127471631627916">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="SLOVE2" country="CH">
+        <iidm:voltageLevel id="SLOVE21" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="SLOVE211" v="400.0" angle="2.149095516094468">
+                    <iidm:property name="geographicalName" value="SI2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="SLOVE211_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="0.0" targetV="400.0" targetQ="0.0" bus="SLOVE211" connectableBus="SLOVE211" p="-0.0" q="-8.439725513915462">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:danglingLine id="SLOVE211 XSLOVE11 1" name="" p0="0.0" q0="0.0" r="0.0" x="10.0" g="0.0" b="0.0" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="-0.0" ucteXnodeCode="XSLOVE11" bus="SLOVE211" connectableBus="SLOVE211" p="299.99998454453174" q="5.626978350752672">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value=""/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="5000.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="OUSTR111 OUSTR211 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="OUSTR111" connectableBus1="OUSTR111" voltageLevelId1="OUSTR11" bus2="OUSTR211" connectableBus2="OUSTR211" voltageLevelId2="OUSTR21" p1="-33.33468347803566" q1="0.03472507276120794" p2="33.33468347803566" q2="0.03472507276120794">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="OUSTR111 OUSTR311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="OUSTR111" connectableBus1="OUSTR111" voltageLevelId1="OUSTR11" bus2="OUSTR311" connectableBus2="OUSTR311" voltageLevelId2="OUSTR21" p1="233.33468165929133" q1="1.7014990238731356" p2="-233.33468165929133" q2="1.7014990238731356">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FRANC111 FRANC211 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FRANC111" connectableBus1="FRANC111" voltageLevelId1="FRANC11" bus2="FRANC211" connectableBus2="FRANC211" voltageLevelId2="FRANC21" p1="-808.622426174853" q1="20.446508995094423" p2="808.622426174853" q2="20.446508995094423">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FRANC111 FRANC311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FRANC111" connectableBus1="FRANC111" voltageLevelId1="FRANC11" bus2="FRANC311" connectableBus2="FRANC311" voltageLevelId2="FRANC31" p1="-654.3910187835542" q1="13.387713635653963" p2="654.3910187835542" q2="13.387713635653963">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FRANC211 FRANC311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FRANC211" connectableBus1="FRANC211" voltageLevelId1="FRANC21" bus2="FRANC311" connectableBus2="FRANC311" voltageLevelId2="FRANC31" p1="154.3910577894789" q1="0.7449110505574121" p2="-154.3910577894789" q2="0.7449110505574121">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="SWISS111 SWISS211 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="SWISS111" connectableBus1="SWISS111" voltageLevelId1="SWISS11" bus2="SWISS211" connectableBus2="SWISS211" voltageLevelId2="SWISS21" p1="845.603271073937" q1="22.360778013885344" p2="-845.603271073937" q2="22.360778013885344">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="SWISS111 SWISS311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="SWISS111" connectableBus1="SWISS111" voltageLevelId1="SWISS11" bus2="SWISS311" connectableBus2="SWISS311" voltageLevelId2="SWISS31" p1="154.3966412828538" q1="0.7449649316293672" p2="-154.3966412828538" q2="0.7449649316293672">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="SWISS211 SWISS311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="SWISS211" connectableBus1="SWISS211" voltageLevelId1="SWISS21" bus2="SWISS311" connectableBus2="SWISS311" voltageLevelId2="SWISS31" p1="-691.3830350560075" q1="14.944807763823206" p2="691.3830350560075" q2="14.944807763823206">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="SWISS131 SMENDR32 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="SWISS131" connectableBus1="SWISS131" voltageLevelId1="SWISS13" bus2="SMENDR32" connectableBus2="SMENDR32" voltageLevelId2="SMENDR3">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ITALY111 ITALY211 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="ITALY111" connectableBus1="ITALY111" voltageLevelId1="ITALY11" bus2="ITALY211" connectableBus2="ITALY211" voltageLevelId2="ITALY21" p1="687.6504756023878" q1="14.783804295799847" p2="-687.6504756023878" q2="14.783804295799847">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ITALY111 ITALY311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="ITALY111" connectableBus1="ITALY111" voltageLevelId1="ITALY11" bus2="ITALY311" connectableBus2="ITALY311" voltageLevelId2="ITALY31" p1="75.36303683877699" q1="0.1774880882378152" p2="-75.36303683877699" q2="0.1774880882378152">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="ITALY211 ITALY311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="ITALY211" connectableBus1="ITALY211" voltageLevelId1="ITALY21" bus2="ITALY311" connectableBus2="ITALY311" voltageLevelId2="ITALY31" p1="-612.3494451773278" q1="11.722164129399683" p2="612.3494451773278" q2="11.722164129399683">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="SLOVE211 SLOVE111 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="SLOVE211" connectableBus1="SLOVE211" voltageLevelId1="SLOVE21" bus2="SLOVE111" connectableBus2="SLOVE111" voltageLevelId2="SLOVE11" p1="-299.9999961243835" q1="2.8127471631627916" p2="299.9999961243835" q2="2.8127471631627916">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FRANC211 SWISS311 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FRANC211" connectableBus1="FRANC211" voltageLevelId1="FRANC21" bus2="SWISS311" connectableBus2="SWISS311" voltageLevelId2="SWISS31" p1="36.98644155345881" q1="0.04274995894835037" p2="-36.98644155345881" q2="0.04274995894835037">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:tieLine id="FRANC111 XFRANC11 1 + XFRANC11 ITALY111 1" danglingLineId1="FRANC111 XFRANC11 1" danglingLineId2="XFRANC11 ITALY111 1">
+        <iidm:property name="status_XNode" value="REAL"/>
+        <iidm:property name="geographicalName" value=""/>
+    </iidm:tieLine>
+    <iidm:tieLine id="SLOVE211 XSLOVE11 1 + XSLOVE11 ITALY111 1" danglingLineId1="SLOVE211 XSLOVE11 1" danglingLineId2="XSLOVE11 ITALY111 1">
+        <iidm:property name="status_XNode" value="REAL"/>
+        <iidm:property name="geographicalName" value=""/>
+    </iidm:tieLine>
+    <iidm:tieLine id="ITALY211 XAUSTR11 1 + XAUSTR11 OUSTR311 1" danglingLineId1="ITALY211 XAUSTR11 1" danglingLineId2="XAUSTR11 OUSTR311 1">
+        <iidm:property name="status_XNode" value="REAL"/>
+        <iidm:property name="geographicalName" value=""/>
+    </iidm:tieLine>
+    <iidm:tieLine id="SWISS211 XSWISS11 1 + XSWISS11 ITALY311 1" danglingLineId1="SWISS211 XSWISS11 1" danglingLineId2="XSWISS11 ITALY311 1">
+        <iidm:property name="status_XNode" value="REAL"/>
+        <iidm:property name="geographicalName" value=""/>
+    </iidm:tieLine>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**
Current implementation of the method used to compute the exchange between two CountryArea instance do not work as expected when a TieLine is connecting the two areas.

**What is the new behavior (if this is a feature change)?**
TieLine are now correctly taken into account in inter CountryArea exchange computation.

