### PR TITLE
CI: New branch name pattern for full Sonar analyses

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'release-v**'
+      - 'full-sonar-analysis-**'
   pull_request:
 
 jobs:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Full sonar analyses are only performed on `main` and `release-v**` branches.


**What is the new behavior (if this is a feature change)?**
Full sonar analyses will also be performed for `full-sonar-analysis-**` branches.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

**This PR is not sufficient.** To have full sonar analyses on these branches, the pattern must also be added to the "long-living branches" definition in the SonarCloud project.
(To have a full report, the analysis must be performed on a branch and not a PR - this is the purpose of this PR - AND the branch must be a long-living one.)

Workflow:
- The developer creates and pushes a `full-sonar-analysis-**` branch
- No PR is needed: the CI is automatically launched
- The corresponding workflow run can be found in the Github project's "Actions" tab
- Once the run is completed, the report can be found in the SonarCloud project's "Branches" tab
- The developer can then push new commits on the branch, create a PR and merge it
- **The creator of the branch is responsible of the report's deletion in SonarCloud** (project's "Branches" tab) since long-living branches' reports won't be automatically deleted by SonarCloud.

Sources:
- [Branch Analysis](https://docs.sonarcloud.io/enriching/branch-analysis/)
- [Branch Analysis Setup](https://docs.sonarcloud.io/enriching/branch-analysis-setup/)
