### PR TITLE
Add an implementation of GlskProvider that uses GlskDocument as data source

### DIFF
--- a/flow-decomposition/pom.xml
+++ b/flow-decomposition/pom.xml
@@ -28,6 +28,10 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-glsk-document-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-sensitivity-analysis-api</artifactId>
         </dependency>
         <dependency>
@@ -39,6 +43,16 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
             <version>${commonscsv.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-glsk-document-io-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-glsk-document-ucte</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProvider.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProvider.java
@@ -23,12 +23,12 @@ import java.util.stream.Collectors;
 /**
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  */
-public class GlskDocumentBasedGlskProvider implements GlskProvider {
+public final class GlskDocumentBasedGlskProvider implements GlskProvider {
     private final GlskDocument glskDocument;
     private final Instant instant;
     private final boolean usingNetworkInstant;
 
-    public GlskDocumentBasedGlskProvider(GlskDocument glskDocument, Instant instant, boolean usingNetworkInstant) {
+    private GlskDocumentBasedGlskProvider(GlskDocument glskDocument, Instant instant, boolean usingNetworkInstant) {
         this.glskDocument = glskDocument;
         this.instant = instant;
         this.usingNetworkInstant = usingNetworkInstant;

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProvider.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.flow_decomposition.glsk_provider;
+
+import com.powsybl.flow_decomposition.GlskProvider;
+import com.powsybl.glsk.api.GlskDocument;
+import com.powsybl.glsk.commons.CountryEICode;
+import com.powsybl.glsk.commons.ZonalData;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.sensitivity.SensitivityVariableSet;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+public class GlskDocumentBasedGlskProvider implements GlskProvider {
+    private final GlskDocument glskDocument;
+    private final Instant instant;
+    private final boolean usingNetworkInstant;
+
+    public GlskDocumentBasedGlskProvider(GlskDocument glskDocument, Instant instant, boolean usingNetworkInstant) {
+        this.glskDocument = glskDocument;
+        this.instant = instant;
+        this.usingNetworkInstant = usingNetworkInstant;
+    }
+
+    @Override
+    public Map<Country, Map<String, Double>> getGlsk(Network network) {
+        Map<Country, Map<String, Double>> perCountryGlsk = getDefaultGlsk(network);
+        updateWithGlskFromDocument(network, perCountryGlsk);
+        return perCountryGlsk;
+    }
+
+    private void updateWithGlskFromDocument(Network network, Map<Country, Map<String, Double>> perCountryGlsk) {
+        getSensitivityVariableSetZonalData(network).getDataPerZone().forEach((countryEicCode, glskData) -> perCountryGlsk.put(new CountryEICode(countryEicCode).getCountry(),
+            glskData.getVariablesById().entrySet().stream().collect(Collectors.toMap(
+                nodeFactorEntry -> nodeFactorEntry.getKey(),
+                nodeFactorEntry -> nodeFactorEntry.getValue().getWeight()
+            ))));
+    }
+
+    private ZonalData<SensitivityVariableSet> getSensitivityVariableSetZonalData(Network network) {
+        Instant glskInstant = getOptionalInstant(network);
+        if (Objects.isNull(glskInstant)) {
+            return glskDocument.getZonalGlsks(network);
+        } else {
+            return glskDocument.getZonalGlsks(network, glskInstant);
+        }
+    }
+
+    private Instant getOptionalInstant(Network network) {
+        if (Objects.isNull(instant)) {
+            if (usingNetworkInstant) {
+                return getNetworkInstant(network);
+            }
+            return null;
+        }
+        return instant;
+    }
+
+    private Instant getNetworkInstant(Network network) {
+        return Instant.ofEpochMilli(network.getCaseDate().getMillis());
+    }
+
+    private Map<Country, Map<String, Double>> getDefaultGlsk(Network network) {
+        return new AutoGlskProvider().getGlsk(network);
+    }
+
+    public static GlskProvider notTimeSpecific(GlskDocument glskDocument) {
+        return new GlskDocumentBasedGlskProvider(glskDocument, null, false);
+    }
+
+    public static GlskProvider basedOnNetworkInstant(GlskDocument glskDocument) {
+        return new GlskDocumentBasedGlskProvider(glskDocument, null, true);
+    }
+
+    public static GlskProvider basedOnGivenInstant(GlskDocument glskDocument, Instant instant) {
+        return new GlskDocumentBasedGlskProvider(glskDocument, instant, false);
+    }
+}

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/TestUtils.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/TestUtils.java
@@ -6,6 +6,8 @@
  */
 package com.powsybl.flow_decomposition;
 
+import com.powsybl.glsk.api.GlskDocument;
+import com.powsybl.glsk.api.io.GlskDocumentImporters;
 import com.powsybl.iidm.network.Bus;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.Terminal;
@@ -28,6 +30,11 @@ public final class TestUtils {
     public static Network importNetwork(String networkResourcePath) {
         String networkName = Paths.get(networkResourcePath).getFileName().toString();
         return Network.read(networkName, TestUtils.class.getResourceAsStream(networkResourcePath));
+    }
+
+    public static GlskDocument importGlskDocument(String glskFileName) {
+        String glskName = Paths.get(glskFileName).getFileName().toString();
+        return GlskDocumentImporters.importGlsk(TestUtils.class.getResourceAsStream(glskName));
     }
 
     public static void assertCoherenceTotalFlow(boolean enableRescaledResults, FlowDecompositionResults flowDecompositionResults) {

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProviderTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProviderTest.java
@@ -50,7 +50,7 @@ class GlskDocumentBasedGlskProviderTest {
     }
 
     @Test
-    void testThatGlskProviderWithGiovenInstantGetsCorrectFactors() {
+    void testThatGlskProviderWithGivenInstantGetsCorrectFactors() {
         String networkFileName = "testCase.xiidm";
         String glskFileName = "GlskUcteFrMultipleInstants.xml";
         Network network = importNetwork(networkFileName);

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProviderTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/glsk_provider/GlskDocumentBasedGlskProviderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.flow_decomposition.glsk_provider;
+
+import com.powsybl.flow_decomposition.GlskProvider;
+import com.powsybl.glsk.api.GlskDocument;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+
+import static com.powsybl.flow_decomposition.TestUtils.importGlskDocument;
+import static com.powsybl.flow_decomposition.TestUtils.importNetwork;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
+ */
+class GlskDocumentBasedGlskProviderTest {
+    private static final double EPSILON = 1e-3;
+
+    @Test
+    void testThatGlskProviderWithFirstInstantGetsCorrectFactors() {
+        String networkFileName = "testCase.xiidm";
+        String glskFileName = "GlskUcteFrUniqueInstant.xml";
+        Network network = importNetwork(networkFileName);
+        GlskDocument glskDocument = importGlskDocument(glskFileName);
+        GlskProvider glskProvider = GlskDocumentBasedGlskProvider.notTimeSpecific(glskDocument);
+        Map<Country, Map<String, Double>> glsks = glskProvider.getGlsk(network);
+        assertEquals(0.5, glsks.get(Country.FR).get("FFR1AA1 _generator"), EPSILON);
+        assertEquals(0.5, glsks.get(Country.FR).get("FFR2AA1 _generator"), EPSILON);
+    }
+
+    @Test
+    void testThatGlskProviderWithNetworkInstantGetsCorrectFactors() {
+        String networkFileName = "testCase.xiidm";
+        String glskFileName = "GlskUcteFrMultipleInstants.xml";
+        Network network = importNetwork(networkFileName);
+        GlskDocument glskDocument = importGlskDocument(glskFileName);
+        GlskProvider glskProvider = GlskDocumentBasedGlskProvider.basedOnNetworkInstant(glskDocument);
+        Map<Country, Map<String, Double>> glsks = glskProvider.getGlsk(network);
+        assertEquals(1, glsks.get(Country.FR).get("FFR1AA1 _generator"), EPSILON);
+    }
+
+    @Test
+    void testThatGlskProviderWithGiovenInstantGetsCorrectFactors() {
+        String networkFileName = "testCase.xiidm";
+        String glskFileName = "GlskUcteFrMultipleInstants.xml";
+        Network network = importNetwork(networkFileName);
+        GlskDocument glskDocument = importGlskDocument(glskFileName);
+        GlskProvider glskProvider = GlskDocumentBasedGlskProvider.basedOnGivenInstant(glskDocument, Instant.parse("2014-01-16T21:00:00Z"));
+        Map<Country, Map<String, Double>> glsks = glskProvider.getGlsk(network);
+        assertEquals(1, glsks.get(Country.FR).get("FFR2AA1 _generator"), EPSILON);
+    }
+
+    @Test
+    void testThatCountriesNotIncludedInGlskDocumentHaveAutoGlskFactorsCalculated() {
+        String networkFileName = "testCase.xiidm";
+        String glskFileName = "GlskUcteFrMultipleInstants.xml";
+        Network network = importNetwork(networkFileName);
+        GlskDocument glskDocument = importGlskDocument(glskFileName);
+        GlskProvider glskProvider = GlskDocumentBasedGlskProvider.basedOnNetworkInstant(glskDocument);
+        Map<Country, Map<String, Double>> glsks = glskProvider.getGlsk(network);
+        assertEquals(0.214, glsks.get(Country.BE).get("BBE1AA1 _generator"), EPSILON);
+        assertEquals(0.429, glsks.get(Country.BE).get("BBE2AA1 _generator"), EPSILON);
+        assertEquals(0.357, glsks.get(Country.BE).get("BBE3AA1 _generator"), EPSILON);
+    }
+}

--- a/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/GlskUcteFrMultipleInstants.xml
+++ b/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/GlskUcteFrMultipleInstants.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GSKDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" DtdVersion="1" DtdRelease="0" xsi:noNamespaceSchemaLocation="gsk-document.xsd">
+    <DocumentIdentification v="17XTSO-CS------W-20160729-F112"/>
+    <DocumentVersion v="1"/>
+    <DocumentType v="Z02"/>
+    <ProcessType v="Z02"/>
+    <SenderIdentification v="17XTSO-CS------W" codingScheme="A01"/>
+    <SenderRole v="A36"/>
+    <ReceiverIdentification v="10XFR-RTE------Q" codingScheme="A01"/>
+    <ReceiverRole v="A04"/>
+    <CreationDateTime v="2017-10-30T09:27:21Z"/>
+    <GSKTimeInterval v="2014-01-15T23:00Z/2014-01-16T23:00Z"/>
+    <Domain v="10YDOM-REGION-1V" codingScheme="A01"/>
+    <GSKSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02" share="100"/>
+        <Area v="10YFR-RTE------C" codingScheme="A01"/>
+        <ManualGSK_Block>
+            <GSK_Name v="FR"/>
+            <TimeInterval v="2014-01-15T23:00Z/2014-01-16T04:00Z"/>
+            <ManualNodes>
+                <NodeName v="FFR1AA1 "/>
+                <Factor v="0.5"/>
+            </ManualNodes>
+            <ManualNodes>
+                <NodeName v="FFR2AA1 "/>
+                <Factor v="0.5"/>
+            </ManualNodes>
+        </ManualGSK_Block>
+        <ManualGSK_Block>
+            <GSK_Name v="FR"/>
+            <TimeInterval v="2014-01-16T04:00Z/2014-01-16T16:00Z"/>
+            <ManualNodes>
+                <NodeName v="FFR1AA1 "/>
+                <Factor v="1"/>
+            </ManualNodes>
+        </ManualGSK_Block>
+        <ManualGSK_Block>
+            <GSK_Name v="FR"/>
+            <TimeInterval v="2014-01-16T16:00Z/2014-01-16T23:00Z"/>
+            <ManualNodes>
+                <NodeName v="FFR2AA1 "/>
+                <Factor v="1"/>
+            </ManualNodes>
+        </ManualGSK_Block>
+    </GSKSeries>
+</GSKDocument>

--- a/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/GlskUcteFrUniqueInstant.xml
+++ b/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/GlskUcteFrUniqueInstant.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<GSKDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" DtdVersion="1" DtdRelease="0" xsi:noNamespaceSchemaLocation="gsk-document.xsd">
+    <DocumentIdentification v="17XTSO-CS------W-20160729-F112"/>
+    <DocumentVersion v="1"/>
+    <DocumentType v="Z02"/>
+    <ProcessType v="Z02"/>
+    <SenderIdentification v="17XTSO-CS------W" codingScheme="A01"/>
+    <SenderRole v="A36"/>
+    <ReceiverIdentification v="10XFR-RTE------Q" codingScheme="A01"/>
+    <ReceiverRole v="A04"/>
+    <CreationDateTime v="2017-10-30T09:27:21Z"/>
+    <GSKTimeInterval v="2014-01-15T23:00Z/2014-01-16T23:00Z"/>
+    <Domain v="10YDOM-REGION-1V" codingScheme="A01"/>
+    <GSKSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02" share="100"/>
+        <Area v="10YFR-RTE------C" codingScheme="A01"/>
+        <ManualGSK_Block>
+            <GSK_Name v="FR"/>
+            <TimeInterval v="2014-01-15T23:00Z/2014-01-16T04:00Z"/>
+            <ManualNodes>
+                <NodeName v="FFR1AA1 "/>
+                <Factor v="0.5"/>
+            </ManualNodes>
+            <ManualNodes>
+                <NodeName v="FFR2AA1 "/>
+                <Factor v="0.5"/>
+            </ManualNodes>
+        </ManualGSK_Block>
+    </GSKSeries>
+</GSKDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Feature

**What is the new behavior (if this is a feature change)?**
Add an implementation of GlskProvider that uses GlskDocument as data source to load GLSKs for all countries. Unavailable GLSKs will be replaced by default proportional country GLSK.

The new implementation also allows to choose the GLSK serie in the document based on :

- The network object case date
- A given input date
