### PR TITLE
Add literal annotation in author's email address

### DIFF
--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/NetworkAreaUtil.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/NetworkAreaUtil.java
@@ -15,7 +15,7 @@ import com.powsybl.iidm.network.extensions.LoadDetail;
 import java.util.List;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 public final class NetworkAreaUtil {
 

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkAreaUtilTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/NetworkAreaUtilTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 class NetworkAreaUtilTest {
 

--- a/cne/cne-converter/src/main/java/com/powsybl/cne/converter/CneConstants.java
+++ b/cne/cne-converter/src/main/java/com/powsybl/cne/converter/CneConstants.java
@@ -7,7 +7,7 @@
 package com.powsybl.cne.converter;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public final class CneConstants {
 

--- a/cne/cne-converter/src/main/java/com/powsybl/cne/converter/CneExportOptions.java
+++ b/cne/cne-converter/src/main/java/com/powsybl/cne/converter/CneExportOptions.java
@@ -7,7 +7,7 @@
 package com.powsybl.cne.converter;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class CneExportOptions {
 

--- a/cne/cne-converter/src/main/java/com/powsybl/cne/converter/CneExporter.java
+++ b/cne/cne-converter/src/main/java/com/powsybl/cne/converter/CneExporter.java
@@ -31,7 +31,7 @@ import static com.powsybl.cne.converter.CneConstants.*;
 /**
  * CNE XML format export of an SecurityAnalysisResult.<p>
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 @AutoService(SecurityAnalysisResultExporter.class)
 public class CneExporter implements SecurityAnalysisResultExporter {

--- a/cne/cne-converter/src/main/java/com/powsybl/cne/converter/SecurityAnalysisResultXml.java
+++ b/cne/cne-converter/src/main/java/com/powsybl/cne/converter/SecurityAnalysisResultXml.java
@@ -22,7 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public final class SecurityAnalysisResultXml {
 

--- a/cne/cne-converter/src/main/java/com/powsybl/cne/converter/SecurityAnalysisResultXmlWriterContext.java
+++ b/cne/cne-converter/src/main/java/com/powsybl/cne/converter/SecurityAnalysisResultXmlWriterContext.java
@@ -19,7 +19,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class SecurityAnalysisResultXmlWriterContext implements XmlWriterContext {
 

--- a/cne/cne-converter/src/test/java/com/powsybl/cne/converter/CneExporterTest.java
+++ b/cne/cne-converter/src/test/java/com/powsybl/cne/converter/CneExporterTest.java
@@ -37,7 +37,7 @@ import java.util.Properties;
 /**
  * Check CneExporter class
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class CneExporterTest extends AbstractConverterTest {
 

--- a/cne/cne-model/src/main/java/com/powsybl/cne/model/ContingencySeries.java
+++ b/cne/cne-model/src/main/java/com/powsybl/cne/model/ContingencySeries.java
@@ -11,7 +11,7 @@ import com.powsybl.contingency.Contingency;
 import java.util.*;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class ContingencySeries {
 

--- a/cne/cne-model/src/main/java/com/powsybl/cne/model/Measurement.java
+++ b/cne/cne-model/src/main/java/com/powsybl/cne/model/Measurement.java
@@ -9,7 +9,7 @@ package com.powsybl.cne.model;
 import com.powsybl.security.LimitViolation;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class Measurement {
 

--- a/cne/cne-model/src/main/java/com/powsybl/cne/model/MeasurementType.java
+++ b/cne/cne-model/src/main/java/com/powsybl/cne/model/MeasurementType.java
@@ -10,7 +10,7 @@ package com.powsybl.cne.model;
 import com.powsybl.security.LimitViolationType;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public enum MeasurementType {
     A01,

--- a/cne/cne-model/src/main/java/com/powsybl/cne/model/MonitoredRegisteredResource.java
+++ b/cne/cne-model/src/main/java/com/powsybl/cne/model/MonitoredRegisteredResource.java
@@ -11,7 +11,7 @@ import com.powsybl.security.LimitViolation;
 import java.util.*;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class MonitoredRegisteredResource {
 

--- a/cne/cne-model/src/main/java/com/powsybl/cne/model/RegisteredResource.java
+++ b/cne/cne-model/src/main/java/com/powsybl/cne/model/RegisteredResource.java
@@ -9,7 +9,7 @@ package com.powsybl.cne.model;
 import com.powsybl.contingency.ContingencyElement;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public class RegisteredResource {
 

--- a/cne/cne-model/src/main/java/com/powsybl/cne/model/UnitSymbol.java
+++ b/cne/cne-model/src/main/java/com/powsybl/cne/model/UnitSymbol.java
@@ -10,7 +10,7 @@ package com.powsybl.cne.model;
 import com.powsybl.security.LimitViolationType;
 
 /**
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 public enum UnitSymbol {
     AMP,

--- a/cne/cne-model/src/test/java/com/powsybl/cne/converter/CneModelTest.java
+++ b/cne/cne-model/src/test/java/com/powsybl/cne/converter/CneModelTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Check cne-model module
  *
- * @author Thomas Adam <tadam at silicom.fr>
+ * @author Thomas Adam {@literal <tadam at silicom.fr>}
  */
 class CneModelTest {
 

--- a/commons/src/main/java-templates/com/powsybl/entsoe/commons/PowsyblEntsoeVersion.java
+++ b/commons/src/main/java-templates/com/powsybl/entsoe/commons/PowsyblEntsoeVersion.java
@@ -12,7 +12,7 @@ import com.powsybl.tools.AbstractVersion;
 import com.powsybl.tools.Version;
 
 /**
- * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ * @author Miora Vedelago {@literal <miora.ralambotiana at rte-france.com>}
  */
 @AutoService(Version.class)
 public class PowsyblEntsoeVersion extends AbstractVersion {

--- a/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
+++ b/emf/src/test/java/com/powsybl/emf/IGMmergeTests.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * @author Bertrand Rix <bertrand.rix at artelys.com>
+ * @author Bertrand Rix {@literal <bertrand.rix at artelys.com>}
  */
 class IGMmergeTests {
 

--- a/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesBoundariesArea.java
+++ b/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesBoundariesArea.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 class CgmesBoundariesArea implements NetworkArea {
 

--- a/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesBoundariesAreaFactory.java
+++ b/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesBoundariesAreaFactory.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 public class CgmesBoundariesAreaFactory implements NetworkAreaFactory {
 

--- a/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsArea.java
+++ b/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsArea.java
@@ -15,7 +15,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 class CgmesVoltageLevelsArea implements NetworkArea {
 

--- a/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsAreaFactory.java
+++ b/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsAreaFactory.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 public class CgmesVoltageLevelsAreaFactory implements NetworkAreaFactory {
 

--- a/entsoe-cgmes-balances-adjustment/src/test/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesBoundariesAreaTest.java
+++ b/entsoe-cgmes-balances-adjustment/src/test/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesBoundariesAreaTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 class CgmesBoundariesAreaTest {
 

--- a/entsoe-cgmes-balances-adjustment/src/test/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsAreaTest.java
+++ b/entsoe-cgmes-balances-adjustment/src/test/java/com/powsybl/entsoe/cgmes/balances_adjustment/util/CgmesVoltageLevelsAreaTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
- * @author Miora Ralambotiana <miora.ralambotiana at rte-france.com>
+ * @author Miora Ralambotiana {@literal <miora.ralambotiana at rte-france.com>}
  */
 class CgmesVoltageLevelsAreaTest {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No, but similar to https://github.com/powsybl/powsybl-core/pull/2753

**What kind of change does this PR introduce?**
Bug fix for javadoc generation

**What is the current behavior?**
Errors related to the author's email address formatting occur when generating the javadoc.
Email addresses were written as `@author Name Surname <email>`

**What is the new behavior (if this is a feature change)?**
No more errors related to that when generating the javadoc.
Email addresses are written as `@author Name Surname {@literal <email> }`
