### PR TITLE
Handle loads in merit order conversion

### DIFF
--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -141,7 +141,7 @@ public final class GlskPointScalableConverter {
         Scalable downScalable = Scalable.stack(glskPoint.getGlskShiftKeys().stream()
                 .filter(glskShiftKey -> glskShiftKey.getMeritOrderPosition() < 0)
                 .sorted(Comparator.comparingInt(GlskShiftKey::getMeritOrderPosition).reversed())
-                .map(getGlskShiftKeyScalableFunction(network )).toArray(Scalable[]::new));
+                .map(getGlskShiftKeyScalableFunction(network)).toArray(Scalable[]::new));
         return Scalable.upDown(upScalable, downScalable);
     }
 

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -141,7 +141,7 @@ public final class GlskPointScalableConverter {
         Scalable downScalable = Scalable.stack(glskPoint.getGlskShiftKeys().stream()
                 .filter(glskShiftKey -> glskShiftKey.getMeritOrderPosition() < 0)
                 .sorted(Comparator.comparingInt(GlskShiftKey::getMeritOrderPosition).reversed())
-                .map(getGlskShiftKeyScalableFunction(network)).toArray(Scalable[]::new));
+                .map(getGlskShiftKeyScalableFunction(network )).toArray(Scalable[]::new));
         return Scalable.upDown(upScalable, downScalable);
     }
 

--- a/glsk/glsk-document-cse/src/test/java/com/powsybl/glsk/cse/CseGlskDocumentImporterTest.java
+++ b/glsk/glsk-document-cse/src/test/java/com/powsybl/glsk/cse/CseGlskDocumentImporterTest.java
@@ -580,7 +580,16 @@ class CseGlskDocumentImporterTest {
         assertEquals(2000., network.getDanglingLine("BBE2AA1  XNODE_1B 1").getP0(), EPSILON); // -1000
         assertEquals(2000., network.getDanglingLine("DDE3AA1  XNODE_1A 1").getP0(), EPSILON); // -3000
         assertEquals(1500., network.getGenerator("FFR1AA1 _generator").getTargetP(), EPSILON); // -500
+    }
 
+    @Test
+    void checkCseGlskDocumentImporterCorrectlyConvertMeritOrderGskBlocksWithLoads() {
+        Network network = Network.read("testCaseWithLoadss.xiidm", getClass().getResourceAsStream("/testCaseWithLoads.xiidm"));
+        GlskDocument glskDocument = GlskDocumentImporters.importGlsk(getClass().getResourceAsStream("/testGlskWithLoads.xml"));
+        Scalable meritOrderGskScalable = glskDocument.getZonalScalable(network).getData("FR_MERITORDER");
+
+        assertNotNull(meritOrderGskScalable);
+        assertEquals(-100., network.getLoad("IMESM121_load").getP0(), EPSILON);
     }
 
     @Test

--- a/glsk/glsk-document-cse/src/test/resources/testCaseWithLoads.xiidm
+++ b/glsk/glsk-document-cse/src/test/resources/testCaseWithLoads.xiidm
@@ -1,0 +1,283 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" xmlns:xn="http://www.itesla_project.eu/schema/iidm/ext/xnode/1_0" id="sdj" caseDate="2023-04-17T15:06:26.827+02:00" forecastDistance="0" sourceFormat="UCTE" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="BBE1AA" country="BE">
+        <iidm:voltageLevel id="BBE1AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE1AA1 ">
+                    <iidm:property name="geographicalName" value="BE1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE1AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE1AA1 _load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="BBE1AA1 " connectableBus="BBE1AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="IMESM1" country="IT">
+            <iidm:voltageLevel id="IMESM12" nominalV="220.0" topologyKind="BUS_BREAKER">
+                <iidm:busBreakerTopology>
+                    <iidm:bus id="IMESM121">
+                        <iidm:property name="geographicalName" value="MESE"/>
+                    </iidm:bus>
+                </iidm:busBreakerTopology>
+            <iidm:load id="IMESM121_load" loadType="UNDEFINED" p0="-100" q0="-100" bus="IMESM121" connectableBus="IMESM121"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="BBE2AA" country="BE">
+        <iidm:voltageLevel id="BBE2AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE2AA1 ">
+                    <iidm:property name="geographicalName" value="BE2"/>
+                </iidm:bus>
+                <iidm:bus id="BBE3AA1 ">
+                    <iidm:property name="geographicalName" value="BE3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE2AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="BBE3AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="BBE2AA1 " connectableBus="BBE2AA1 "/>
+            <iidm:load id="BBE3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="BBE3AA1 " connectableBus="BBE3AA1 "/>
+            <iidm:danglingLine id="BBE2AA1  XNODE_1B 1" name="XNODE_1B" p0="1000.0" q0="0.0" r="1.0E-4" x="0.05" g="0.0" b="7.441799999999999E-7" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0" generationTargetQ="0.078" ucteXnodeCode="XNODE_1B" bus="BBE2AA1 " connectableBus="BBE2AA1 ">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="REAL"/>
+                <iidm:property name="geographicalName" value="XNODE_1B"/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="1635.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="BBE2AA1  BBE3AA1  1" r="0.0" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="BBE3AA1 " connectableBus1="BBE3AA1 " voltageLevelId1="BBE2AA1" bus2="BBE2AA1 " connectableBus2="BBE2AA1 " voltageLevelId2="BBE2AA1">
+            <iidm:property name="nomimalPower" value="1000.0"/>
+            <iidm:property name="elementName" value="PST"/>
+            <iidm:phaseTapChanger lowTapPosition="-16" tapPosition="0" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.2276423729910535"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.839110508104064"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.4504442277066305"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.061652408895631"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.672743946063913"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.283727749689918"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.894612745121778"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.505407871356285"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.1161220798131644"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.7267643331050597"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.337343603803646"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.9478688732023104"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.5583491300758083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.1687933694373345"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.7792105912934298"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.3896097993971608"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.3896097993971608"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.7792105912934298"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.1687933694373345"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.5583491300758083"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.9478688732023104"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.337343603803646"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.7267643331050597"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.1161220798131644"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.505407871356285"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.894612745121778"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.283727749689918"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.672743946063913"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.061652408895631"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.4504442277066305"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.839110508104064"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.2276423729910535"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="5000.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="DDE1AA" country="DE">
+        <iidm:voltageLevel id="DDE1AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE1AA1 ">
+                    <iidm:property name="geographicalName" value="DE1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE1AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE1AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="DDE1AA1 " connectableBus="DDE1AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE2AA" country="DE">
+        <iidm:voltageLevel id="DDE2AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE2AA1 ">
+                    <iidm:property name="geographicalName" value="DE2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE2AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE2AA1 _load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="DDE2AA1 " connectableBus="DDE2AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE3AA" country="DE">
+        <iidm:voltageLevel id="DDE3AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE3AA1 ">
+                    <iidm:property name="geographicalName" value="DE3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE3AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE3AA1 _load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="DDE3AA1 " connectableBus="DDE3AA1 "/>
+            <iidm:danglingLine id="DDE3AA1  XNODE_1A 1" name="XNODE_1A" fictitious="true" p0="-1000.0" q0="0.0" r="0.005" x="0.05" g="0.0" b="4.0E-7" generationMinP="-1.7976931348623157E308" generationMaxP="1.7976931348623157E308" generationVoltageRegulationOn="false" generationTargetP="-0.0016" generationTargetQ="0.0134" ucteXnodeCode="XNODE_1A" bus="DDE3AA1 " connectableBus="DDE3AA1 ">
+                <iidm:property name="isCoupler" value="false"/>
+                <iidm:property name="status_XNode" value="EQUIVALENT"/>
+                <iidm:property name="geographicalName" value="XNODE_1A"/>
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+                <iidm:currentLimits permanentLimit="3600.0"/>
+            </iidm:danglingLine>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR1AA" country="FR">
+        <iidm:voltageLevel id="FFR1AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR1AA1 ">
+                    <iidm:property name="geographicalName" value="FR1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR1AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="FFR1AA1 " connectableBus="FFR1AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR2AA" country="FR">
+        <iidm:voltageLevel id="FFR2AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR2AA1 ">
+                    <iidm:property name="geographicalName" value="FR2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR2AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR2AA1 _load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="FFR2AA1 " connectableBus="FFR2AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR3AA" country="FR">
+        <iidm:voltageLevel id="FFR3AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR3AA1 ">
+                    <iidm:property name="geographicalName" value="FR3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR3AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR3AA1 _load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="FFR3AA1 " connectableBus="FFR3AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL1AA" country="NL">
+        <iidm:voltageLevel id="NNL1AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL1AA1 ">
+                    <iidm:property name="geographicalName" value="NL1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL1AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL1AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL1AA1 " connectableBus="NNL1AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL2AA" country="NL">
+        <iidm:voltageLevel id="NNL2AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL2AA1 ">
+                    <iidm:property name="geographicalName" value="NL2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL2AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL2AA1 _load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL2AA1 " connectableBus="NNL2AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL3AA" country="NL">
+        <iidm:voltageLevel id="NNL3AA1" nominalV="400.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL3AA1 ">
+                    <iidm:property name="geographicalName" value="NL3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL3AA1 _generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 ">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL3AA1 _load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="NNL3AA1 " connectableBus="NNL3AA1 "/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="BBE1AA1  BBE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE2AA1 " connectableBus2="BBE2AA1 " voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA1 " connectableBus1="BBE1AA1 " voltageLevelId1="BBE1AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR2AA1 " connectableBus2="FFR2AA1 " voltageLevelId2="FFR2AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA1 " connectableBus1="FFR1AA1 " voltageLevelId1="FFR1AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR2AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE2AA1 " connectableBus2="DDE2AA1 " voltageLevelId2="DDE2AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA1 " connectableBus1="DDE1AA1 " voltageLevelId1="DDE1AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL2AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL2AA1 " connectableBus2="NNL2AA1 " voltageLevelId2="NNL2AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA1 " connectableBus1="NNL1AA1 " voltageLevelId1="NNL1AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA1  DDE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA1 " connectableBus1="FFR2AA1 " voltageLevelId1="FFR2AA1" bus2="DDE3AA1 " connectableBus2="DDE3AA1 " voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA1  NNL3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA1 " connectableBus1="DDE2AA1 " voltageLevelId1="DDE2AA1" bus2="NNL3AA1 " connectableBus2="NNL3AA1 " voltageLevelId2="NNL3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA1  BBE3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA1 " connectableBus1="NNL2AA1 " voltageLevelId1="NNL2AA1" bus2="BBE3AA1 " connectableBus2="BBE3AA1 " voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE2AA1  FFR3AA1  1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE2AA1 " connectableBus1="BBE2AA1 " voltageLevelId1="BBE2AA1" bus2="FFR3AA1 " connectableBus2="FFR3AA1 " voltageLevelId2="FFR3AA1">
+        <iidm:currentLimits1 permanentLimit="5000.0"/>
+        <iidm:currentLimits2 permanentLimit="5000.0"/>
+    </iidm:line>
+    <iidm:extension id="DDE3AA1  XNODE_1A 1">
+        <xn:xnode code="XNODE_1A"/>
+    </iidm:extension>
+    <iidm:extension id="BBE2AA1  XNODE_1B 1">
+        <xn:xnode code="XNODE_1B"/>
+    </iidm:extension>
+</iidm:network>

--- a/glsk/glsk-document-cse/src/test/resources/testGlskWithLoads.xml
+++ b/glsk/glsk-document-cse/src/test/resources/testGlskWithLoads.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<GSKDocument DtdVersion="5" DtdRelease="0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="gsk-document.xsd">
+    <DocumentIdentification v="testGlsk"/>
+    <DocumentVersion v="1"/>
+    <DocumentType v="Z02"/>
+    <ProcessType v="Z02"/>
+    <SenderIdentification v="10VCSEEH4MMD-NDO" codingScheme="A01"/>
+    <SenderRole v="A36"/>
+    <ReceiverIdentification v="10X1001A1001A345" codingScheme="A01"/>
+    <ReceiverRole v="A04"/>
+    <CreationDateTime v="2020-09-15T17:59:09Z"/>
+    <GSKTimeInterval v="2020-09-16T22:00Z/2020-09-16T23:00Z"/>
+    <Domain v="10YDOM-1001A061T" codingScheme="A01"/>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_MANUAL" codingScheme="A01"/>
+        <Name v="FR_MANUAL"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <ManualGSKBlock>
+            <Factor v="1"/>
+            <Node>
+                <Name v="FFR1AA1 "/>
+                <Factor v="70"/>
+            </Node>
+            <Node>
+                <Name v="XNODE_1B"/>
+                <Factor v="30"/>
+            </Node>
+        </ManualGSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_PROPGSK" codingScheme="A01"/>
+        <Name v="FR_PROPGSK"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <PropGSKBlock>
+            <Factor v="1"/>
+            <Node>
+                <Name v="FFR1AA1 "/>
+            </Node>
+            <Node>
+                <Name v="XNODE_1A"/>
+            </Node>
+            <Node>
+                <Name v="XNODE_1B"/>
+            </Node>
+        </PropGSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_PROPGLSK" codingScheme="A01"/>
+        <Name v="FR_PROPGLSK"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <PropGSKBlock>
+            <Factor v="0.7"/>
+            <Node>
+                <Name v="FFR1AA1 "/>
+            </Node>
+            <Node>
+                <Name v="FFR2AA1 "/>
+            </Node>
+            <Node>
+                <Name v="XNODE_1B"/>
+            </Node>
+        </PropGSKBlock>
+        <PropLSKBlock>
+            <Factor v="0.3"/>
+            <Node>
+                <Name v="FFR1AA1 "/>
+            </Node>
+            <Node>
+                <Name v="XNODE_1A"/>
+            </Node>
+        </PropLSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_MERITORDER" codingScheme="A01"/>
+        <Name v="FR_MERITORDER"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <MeritOrderGSKBlock>
+            <Factor v="1"/>
+            <Up>
+                <Factor v="1"/>
+                <Node>
+                    <Name v="IMESM121"/>
+                    <Pmax v="-100"/>
+                </Node>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmax v="-2900"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1A"/>
+                    <Pmax v="-2000"/>
+                </Node>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmax v="-6000"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1B"/>
+                    <Pmax v="-2000"/>
+                </Node>
+            </Up>
+            <Down>
+                <Factor v="1"/>
+                <Node>
+                    <Name v="XNODE_1B"/>
+                    <Pmin v="2000"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1A"/>
+                    <Pmin v="2000"/>
+                </Node>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmin v="0"/>
+                </Node>
+            </Down>
+        </MeritOrderGSKBlock>
+    </TimeSeries>
+    <TimeSeries>
+        <TimeSeriesIdentification v="1"/>
+        <BusinessType v="Z02"/>
+        <Area v="FR_MERIT_ISSUE_PC" codingScheme="A01"/>
+        <Name v="FR_MERIT_ISSUE_PC"/>
+        <TimeInterval v="2020-09-16T22:00Z/2020-09-16T22:59Z"/>
+        <MeritOrderGSKBlock>
+            <Factor v="1"/>
+            <Up>
+                <Factor v="1"/>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmax v="-3000"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1A"/>
+                    <Pmax v="-500"/>
+                </Node>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmax v="-6000"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1B"/>
+                    <Pmax v="-500"/>
+                </Node>
+            </Up>
+            <Down>
+                <Factor v="1"/>
+                <Node>
+                    <Name v="FFR1AA1 "/>
+                    <Pmin v="0"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1B"/>
+                    <Pmin v="500"/>
+                </Node>
+                <Node>
+                    <Name v="XNODE_1A"/>
+                    <Pmin v="500"/>
+                </Node>
+            </Down>
+        </MeritOrderGSKBlock>
+    </TimeSeries>
+</GSKDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?**
<!-- You can also link to an open issue here -->
In the merit order conversion, everything that is not a generator is considered a dangline line. I had the case where a load would be seen as a dangline line and would trigger a null pointer exception

**What is the new behavior (if this is a feature change)?**
I add a check to verify if a glskShiftKey is a generator, a load, or a dangline line

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
