### PR TITLE
AutoGlskProvider uses connected generators, and don't crash when the sum of target Ps is zero

### DIFF
--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/glsk_provider/AutoGlskProviderTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/glsk_provider/AutoGlskProviderTests.java
@@ -29,10 +29,47 @@ class AutoGlskProviderTests {
         String loadBe = "BLOAD 11_load";
         String genFr = "FGEN1 11_generator";
         Network network = importNetwork(networkFileName);
-        AutoGlskProvider autoGlskProvider = new AutoGlskProvider();
-        Map<Country, Map<String, Double>> glsks = autoGlskProvider.getGlsk(network);
+
+        Map<Country, Map<String, Double>> glsks = new AutoGlskProvider().getGlsk(network);
+
         assertEquals(1.0, glsks.get(Country.FR).get(genFr), EPSILON);
         assertEquals(1.0, glsks.get(Country.BE).get(genBe), EPSILON);
         assertNull(glsks.get(Country.BE).get(loadBe));
     }
+
+    @Test
+    void testThatGlskIgnoreDisconnectedGenerators() {
+        String networkFileName = "NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_COUNTRIES.uct";
+        String genBe = "BGEN2 11_generator";
+        String loadBe = "BLOAD 11_load";
+        String genFr = "FGEN1 11_generator";
+        Network network = importNetwork(networkFileName);
+
+        network.getGenerator(genFr).getTerminal().disconnect();
+
+        Map<Country, Map<String, Double>> glsks = new AutoGlskProvider().getGlsk(network);
+
+        assertNull(glsks.get(Country.FR).get(genFr));
+
+        assertEquals(1.0, glsks.get(Country.BE).get(genBe), EPSILON);
+        assertNull(glsks.get(Country.BE).get(loadBe));
+    }
+
+    @Test
+    void testThatGlskWorkForNullTargetP() {
+        String networkFileName = "NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_COUNTRIES.uct";
+        String genBe = "BGEN2 11_generator";
+        String loadBe = "BLOAD 11_load";
+        String genFr = "FGEN1 11_generator";
+        Network network = importNetwork(networkFileName);
+
+        network.getGenerator(genFr).setTargetP(0.0);
+
+        Map<Country, Map<String, Double>> glsks = new AutoGlskProvider().getGlsk(network);
+
+        assertEquals(1.0, glsks.get(Country.FR).get(genFr), EPSILON);
+        assertEquals(1.0, glsks.get(Country.BE).get(genBe), EPSILON);
+        assertNull(glsks.get(Country.BE).get(loadBe));
+    }
+
 }


### PR DESCRIPTION
Take only connected generators into account for the AutoGlskProvider.

If the sum of targetPs of a country equals 0.0, all generators take an equal part into the total value. This prevents dividing by 0.

**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
The AutoGlskProvider takes into consideration connected generators only.
It also fixes a bug (dividing by 0) when the generators have a target P equal to 0.
