### PR TITLE
Flow decomposition observers

### DIFF
--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/AcReferenceFlowComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/AcReferenceFlowComputer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.flow_decomposition;
+
+import com.powsybl.iidm.network.Branch;
+import com.powsybl.iidm.network.Identifiable;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
+ */
+class AcReferenceFlowComputer {
+    private static ReferenceFlowComputer flowComputer = new ReferenceFlowComputer();
+
+    Map<String, Double> run(Collection<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
+        if (loadFlowServiceAcResult.fallbackHasBeenActivated()) {
+            return xnecList.stream().collect(Collectors.toMap(Identifiable::getId, branch -> Double.NaN));
+        }
+
+        return flowComputer.run(xnecList);
+    }
+}

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -15,8 +15,6 @@ import com.powsybl.loadflow.LoadFlow;
 import com.powsybl.loadflow.LoadFlowParameters;
 import com.powsybl.sensitivity.SensitivityAnalysis;
 import com.powsybl.sensitivity.SensitivityVariableType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -28,8 +26,6 @@ import java.util.stream.Collectors;
  * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
  */
 public class FlowDecompositionComputer {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(FlowDecompositionComputer.class);
 
     static final String DEFAULT_LOAD_FLOW_PROVIDER = null;
     static final String DEFAULT_SENSITIVITY_ANALYSIS_PROVIDER = null;
@@ -142,13 +138,15 @@ public class FlowDecompositionComputer {
                                        LoadFlowRunningService.Result loadFlowServiceAcResult) {
         saveAcReferenceFlow(flowDecompositionResultsBuilder, xnecList, loadFlowServiceAcResult);
         compensateLosses(network);
+        observers.computedAcFlows(network, loadFlowServiceAcResult);
 
         // None
         NetworkMatrixIndexes networkMatrixIndexes = new NetworkMatrixIndexes(network, new ArrayList<>(xnecList));
-        observers.computedAcFlows(network, networkMatrixIndexes, loadFlowServiceAcResult.fallbackHasBeenActivated());
+        observers.computedAcNodalInjections(networkMatrixIndexes, loadFlowServiceAcResult.fallbackHasBeenActivated());
 
         runDcLoadFlow(network);
-        observers.computedDcFlows(network, networkMatrixIndexes);
+        observers.computedDcFlows(network);
+        observers.computedDcNodalInjections(networkMatrixIndexes);
 
         SparseMatrixWithIndexesTriplet nodalInjectionsMatrix = getNodalInjectionsMatrix(network,
             netPositions, networkMatrixIndexes, glsks);
@@ -161,8 +159,6 @@ public class FlowDecompositionComputer {
         observers.computedPtdfMatrix(ptdfMatrix);
         SparseMatrixWithIndexesTriplet psdfMatrix = getPsdfMatrix(networkMatrixIndexes, sensitivityAnalyser);
         observers.computedPsdfMatrix(psdfMatrix);
-        // psdf variation du flux d'un ligne en changeant la position d'un faceshifter
-        // vérifier que les PST tap positions sont inclues dans la PSDF
 
         // None
         computeAllocatedAndLoopFlows(flowDecompositionResultsBuilder, nodalInjectionsMatrix, ptdfMatrix);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -145,8 +145,10 @@ public class FlowDecompositionComputer {
 
         // None
         NetworkMatrixIndexes networkMatrixIndexes = new NetworkMatrixIndexes(network, new ArrayList<>(xnecList));
+        observers.computedAcFlows(network, networkMatrixIndexes);
 
         runDcLoadFlow(network);
+        observers.computedDcFlows(network, networkMatrixIndexes);
 
         SparseMatrixWithIndexesTriplet nodalInjectionsMatrix = getNodalInjectionsMatrix(network,
             netPositions, networkMatrixIndexes, glsks);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -145,7 +145,7 @@ public class FlowDecompositionComputer {
 
         // None
         NetworkMatrixIndexes networkMatrixIndexes = new NetworkMatrixIndexes(network, new ArrayList<>(xnecList));
-        observers.computedAcFlows(network, networkMatrixIndexes);
+        observers.computedAcFlows(network, networkMatrixIndexes, loadFlowServiceAcResult.fallbackHasBeenActivated());
 
         runDcLoadFlow(network);
         observers.computedDcFlows(network, networkMatrixIndexes);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -28,7 +28,7 @@ public interface FlowDecompositionObserver {
      */
     void computedPsdfMatrix(Map<String, Map<String, Double>> map);
 
-    void computedAcFlows(Map<String, Double> positions);
+    void computedAcFlows(Map<String, Double> positions, boolean fallbackHasBeenActivated);
 
     void computedDcFlows(Map<String, Double> positions);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -27,4 +27,8 @@ public interface FlowDecompositionObserver {
      * @param map the matrix indexed by (line, node)
      */
     void computedPsdfMatrix(Map<String, Map<String, Double>> map);
+
+    void computedAcFlows(Map<String, Double> positions);
+
+    void computedDcFlows(Map<String, Double> positions);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
 package com.powsybl.flow_decomposition;
 
 import com.powsybl.iidm.network.Country;
@@ -28,7 +34,11 @@ public interface FlowDecompositionObserver {
      */
     void computedPsdfMatrix(Map<String, Map<String, Double>> map);
 
-    void computedAcFlows(Map<String, Double> positions, boolean fallbackHasBeenActivated);
+    void computedAcNodalInjections(Map<String, Double> positions, boolean fallbackHasBeenActivated);
 
-    void computedDcFlows(Map<String, Double> positions);
+    void computedDcNodalInjections(Map<String, Double> positions);
+
+    void computedAcFlows(Map<String, Double> flows);
+
+    void computedDcFlows(Map<String, Double> flows);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -6,13 +6,25 @@ import java.util.Map;
 
 public interface FlowDecompositionObserver {
 
+    void runStart();
+
+    void runDone();
+
     void computingBaseCase();
+
     void computingContingency(String contingencyId);
 
     void computedGlsk(Map<Country, Map<String, Double>> glsks);
 
     void computedNetPositions(Map<Country, Double> netPositions);
-    void computedNodalInjectionsMatrix(SparseMatrixWithIndexesTriplet nodalInjectionsMatrix);
-    void computedPtdfMatrix(SparseMatrixWithIndexesTriplet ptdfMatrix);
-    void computedPsdfMatrix(SparseMatrixWithIndexesTriplet matrix);
+
+    void computedNodalInjectionsMatrix(Map<String, Map<String, Double>> map);
+
+    void computedPtdfMatrix(Map<String, Map<String, Double>> map);
+
+    /**
+     * Called when the psdf matrix is ready
+     * @param map the matrix indexed by (line, node)
+     */
+    void computedPsdfMatrix(Map<String, Map<String, Double>> map);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -12,33 +12,89 @@ import java.util.Map;
 
 public interface FlowDecompositionObserver {
 
+    /**
+     * Called when the computation starts
+     */
     void runStart();
 
+    /**
+     * Called when the computation is done
+     */
     void runDone();
 
+    /**
+     * Called when the base case starts to be computed
+     */
     void computingBaseCase();
 
+    /**
+     * Called when starting to compute for the contingency
+     *
+     * @param contingencyId The current contingency id
+     */
     void computingContingency(String contingencyId);
 
+    /**
+     * Called when Glsk are computed thanks to the GlskProvider (during base case computation)
+     *
+     * @param glsks the Glsks per country per generator
+     */
     void computedGlsk(Map<Country, Map<String, Double>> glsks);
 
+    /**
+     * Called when net positions are computed (during base case computation)
+     *
+     * @param netPositions the net positions per country
+     */
     void computedNetPositions(Map<Country, Double> netPositions);
 
-    void computedNodalInjectionsMatrix(Map<String, Map<String, Double>> map);
-
-    void computedPtdfMatrix(Map<String, Map<String, Double>> map);
+    /**
+     * Called when the nodal injection matrix is computed (during n-state or contingency)
+     *
+     * @param nodalInjections the matrix of nodal injections indexed by(node, flow)
+     */
+    void computedNodalInjectionsMatrix(Map<String, Map<String, Double>> nodalInjections);
 
     /**
-     * Called when the psdf matrix is ready
-     * @param map the matrix indexed by (line, node)
+     * Called when the PTDF matrix is computed (during n-state or contingency)
+     *
+     * @param pdtfMatrix the matrix of ptdf indexed by (line, node)
      */
-    void computedPsdfMatrix(Map<String, Map<String, Double>> map);
+    void computedPtdfMatrix(Map<String, Map<String, Double>> pdtfMatrix);
 
+    /**
+     * Called when the psdf matrix is computed (during n-state or contingency)
+     *
+     * @param psdfMatrix the matrix of psdf indexed by (line, node)
+     */
+    void computedPsdfMatrix(Map<String, Map<String, Double>> psdfMatrix);
+
+    /**
+     * Called when the AC nodal injections matrix is computed (during n-state or contingency)
+     *
+     * @param positions the positions after AC loadflow
+     * @param fallbackHasBeenActivated true if AC loadflow didn't converge
+     */
     void computedAcNodalInjections(Map<String, Double> positions, boolean fallbackHasBeenActivated);
 
+    /**
+     * Called when the DC nodal injections matrix is computed (during n-state or contingency)
+     *
+     * @param positions the positions after DC loadflow
+     */
     void computedDcNodalInjections(Map<String, Double> positions);
 
+    /**
+     * Called when the AC loadflow is computed (during n-state or contingency)
+     *
+     * @param flows the flows for all branches
+     */
     void computedAcFlows(Map<String, Double> flows);
 
+    /**
+     * Called when the DC loadflow is computed (during n-state or contingency)
+     *
+     * @param flows the flows for all branches
+     */
     void computedDcFlows(Map<String, Double> flows);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -32,7 +32,7 @@ public interface FlowDecompositionObserver {
     void computingBaseCase();
 
     /**
-     * Called when starting to compute for the contingency
+     * Called when a contingency computation starts
      *
      * @param contingencyId The current contingency id
      */
@@ -46,35 +46,35 @@ public interface FlowDecompositionObserver {
     void computedGlsk(Map<Country, Map<String, Double>> glsks);
 
     /**
-     * Called when net positions are computed (during base case computation)
+     * Called when net positions are computed (for base case computation)
      *
      * @param netPositions the net positions per country
      */
     void computedNetPositions(Map<Country, Double> netPositions);
 
     /**
-     * Called when the nodal injection matrix is computed (during n-state or contingency)
+     * Called when the nodal injection matrix is computed (for base case or contingency)
      *
      * @param nodalInjections the matrix of nodal injections indexed by(node, flow)
      */
     void computedNodalInjectionsMatrix(Map<String, Map<String, Double>> nodalInjections);
 
     /**
-     * Called when the PTDF matrix is computed (during n-state or contingency)
+     * Called when the PTDF matrix is computed (for base case or contingency)
      *
      * @param pdtfMatrix the matrix of ptdf indexed by (line, node)
      */
     void computedPtdfMatrix(Map<String, Map<String, Double>> pdtfMatrix);
 
     /**
-     * Called when the psdf matrix is computed (during n-state or contingency)
+     * Called when the PSDF matrix is computed (for base case or contingency)
      *
      * @param psdfMatrix the matrix of psdf indexed by (line, node)
      */
     void computedPsdfMatrix(Map<String, Map<String, Double>> psdfMatrix);
 
     /**
-     * Called when the AC nodal injections matrix is computed (during n-state or contingency)
+     * Called when the AC nodal injections matrix is computed (for base case or contingency)
      *
      * @param positions the positions after AC loadflow
      * @param fallbackHasBeenActivated true if AC loadflow didn't converge
@@ -82,21 +82,21 @@ public interface FlowDecompositionObserver {
     void computedAcNodalInjections(Map<String, Double> positions, boolean fallbackHasBeenActivated);
 
     /**
-     * Called when the DC nodal injections matrix is computed (during n-state or contingency)
+     * Called when the DC nodal injections matrix is computed (for base case or contingency)
      *
      * @param positions the positions after DC loadflow
      */
     void computedDcNodalInjections(Map<String, Double> positions);
 
     /**
-     * Called when the AC loadflow is computed (during n-state or contingency)
+     * Called when the AC loadflow is computed (for base case or contingency)
      *
      * @param flows the flows for all branches
      */
     void computedAcFlows(Map<String, Double> flows);
 
     /**
-     * Called when the DC loadflow is computed (during n-state or contingency)
+     * Called when the DC loadflow is computed (for base case or contingency)
      *
      * @param flows the flows for all branches
      */

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -1,0 +1,18 @@
+package com.powsybl.flow_decomposition;
+
+import com.powsybl.iidm.network.Country;
+
+import java.util.Map;
+
+public interface FlowDecompositionObserver {
+
+    void computingBaseCase();
+    void computingContingency(String contingencyId);
+
+    void computedGlsk(Map<Country, Map<String, Double>> glsks);
+
+    void computedNetPositions(Map<Country, Double> netPositions);
+    void computedNodalInjectionsMatrix(SparseMatrixWithIndexesTriplet nodalInjectionsMatrix);
+    void computedPtdfMatrix(SparseMatrixWithIndexesTriplet ptdfMatrix);
+    void computedPsdfMatrix(SparseMatrixWithIndexesTriplet matrix);
+}

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -1,8 +1,9 @@
 /*
- * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * Copyright (c) 2024, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.flow_decomposition;
 
@@ -10,6 +11,9 @@ import com.powsybl.iidm.network.Country;
 
 import java.util.Map;
 
+/**
+ * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
+ */
 public interface FlowDecompositionObserver {
 
     /**

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -1,6 +1,7 @@
 package com.powsybl.flow_decomposition;
 
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,6 +68,32 @@ public class FlowDecompositionObserverList {
 
     public void computedPsdfMatrix(SparseMatrixWithIndexesTriplet matrix) {
         sendMatrix(FlowDecompositionObserver::computedPsdfMatrix, matrix);
+    }
+
+    public void computedAcFlows(Network network, NetworkMatrixIndexes networkMatrixIndexes) {
+        if (observers.isEmpty()) {
+            return;
+        }
+
+        ReferenceNodalInjectionComputer referenceNodalInjectionComputer = new ReferenceNodalInjectionComputer();
+        Map<String, Double> results = referenceNodalInjectionComputer.run(networkMatrixIndexes.getNodeList());
+
+        for (FlowDecompositionObserver o : observers) {
+            o.computedAcFlows(results);
+        }
+    }
+
+    public void computedDcFlows(Network network, NetworkMatrixIndexes networkMatrixIndexes) {
+        if (observers.isEmpty()) {
+            return;
+        }
+
+        ReferenceNodalInjectionComputer referenceNodalInjectionComputer = new ReferenceNodalInjectionComputer();
+        Map<String, Double> results = referenceNodalInjectionComputer.run(networkMatrixIndexes.getNodeList());
+
+        for (FlowDecompositionObserver o : observers) {
+            o.computedDcFlows(results);
+        }
     }
 
     private void sendMatrix(MatrixNotification notification, SparseMatrixWithIndexesTriplet matrix) {

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -1,0 +1,72 @@
+package com.powsybl.flow_decomposition;
+
+import com.powsybl.iidm.network.Country;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class FlowDecompositionObserverList implements FlowDecompositionObserver {
+    private final List<FlowDecompositionObserver> observers;
+
+    public FlowDecompositionObserverList() {
+        this.observers = new ArrayList<>();
+    }
+
+    public void addObserver(FlowDecompositionObserver o) {
+        this.observers.add(o);
+    }
+
+    public void removeObserver(FlowDecompositionObserver o) {
+        this.observers.remove(o);
+    }
+
+    @Override
+    public void computingBaseCase() {
+        for (FlowDecompositionObserver o : observers) {
+            o.computingBaseCase();
+        }
+    }
+
+    @Override
+    public void computingContingency(String contingencyId) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computingContingency(contingencyId);
+        }
+    }
+
+    @Override
+    public void computedGlsk(Map<Country, Map<String, Double>> glsks) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computedGlsk(glsks);
+        }
+    }
+
+    @Override
+    public void computedNetPositions(Map<Country, Double> netPositions) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computedNetPositions(netPositions);
+        }
+    }
+
+    @Override
+    public void computedNodalInjectionsMatrix(SparseMatrixWithIndexesTriplet matrix) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computedNodalInjectionsMatrix(matrix);
+        }
+    }
+
+    @Override
+    public void computedPtdfMatrix(SparseMatrixWithIndexesTriplet matrix) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computedPtdfMatrix(matrix);
+        }
+    }
+
+    @Override
+    public void computedPsdfMatrix(SparseMatrixWithIndexesTriplet matrix) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computedPsdfMatrix(matrix);
+        }
+    }
+}

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -1,8 +1,9 @@
 /*
- * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * Copyright (c) 2024, Coreso SA (https://www.coreso.eu/) and TSCNET Services GmbH (https://www.tscnet.eu/)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
  */
 package com.powsybl.flow_decomposition;
 
@@ -16,6 +17,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
+ */
 public class FlowDecompositionObserverList {
     private final List<FlowDecompositionObserver> observers;
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -9,13 +9,11 @@ package com.powsybl.flow_decomposition;
 
 import com.powsybl.flow_decomposition.LoadFlowRunningService.Result;
 import com.powsybl.iidm.network.Country;
-import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
@@ -88,13 +86,8 @@ public class FlowDecompositionObserverList {
             return;
         }
 
-        Map<String, Double> acFlows;
-        if (loadFlowServiceAcResult.fallbackHasBeenActivated()) {
-            acFlows = network.getBranchStream().collect(Collectors.toMap(Identifiable::getId, branch -> Double.NaN));
-        } else {
-            ReferenceFlowComputer flowComputer = new ReferenceFlowComputer();
-            acFlows = flowComputer.run(network.getBranchStream().collect(Collectors.toSet()));
-        }
+        Map<String, Double> acFlows =
+                new AcReferenceFlowComputer().run(network.getBranchStream().toList(), loadFlowServiceAcResult);
 
         for (FlowDecompositionObserver o : observers) {
             o.computedAcFlows(acFlows);
@@ -106,8 +99,7 @@ public class FlowDecompositionObserverList {
             return;
         }
 
-        ReferenceFlowComputer flowComputer = new ReferenceFlowComputer();
-        Map<String, Double> dcFlows = flowComputer.run(network.getBranchStream().collect(Collectors.toSet()));
+        Map<String, Double> dcFlows = new ReferenceFlowComputer().run(network.getBranchStream().toList());
 
         for (FlowDecompositionObserver o : observers) {
             o.computedDcFlows(dcFlows);
@@ -119,8 +111,7 @@ public class FlowDecompositionObserverList {
             return;
         }
 
-        ReferenceNodalInjectionComputer referenceNodalInjectionComputer = new ReferenceNodalInjectionComputer();
-        Map<String, Double> results = referenceNodalInjectionComputer.run(networkMatrixIndexes.getNodeList());
+        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(networkMatrixIndexes.getNodeList());
 
         for (FlowDecompositionObserver o : observers) {
             o.computedAcNodalInjections(results, fallbackHasBeenActivated);
@@ -132,8 +123,7 @@ public class FlowDecompositionObserverList {
             return;
         }
 
-        ReferenceNodalInjectionComputer referenceNodalInjectionComputer = new ReferenceNodalInjectionComputer();
-        Map<String, Double> results = referenceNodalInjectionComputer.run(networkMatrixIndexes.getNodeList());
+        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(networkMatrixIndexes.getNodeList());
 
         for (FlowDecompositionObserver o : observers) {
             o.computedDcNodalInjections(results);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -70,7 +70,7 @@ public class FlowDecompositionObserverList {
         sendMatrix(FlowDecompositionObserver::computedPsdfMatrix, matrix);
     }
 
-    public void computedAcFlows(Network network, NetworkMatrixIndexes networkMatrixIndexes) {
+    public void computedAcFlows(Network network, NetworkMatrixIndexes networkMatrixIndexes, boolean fallbackHasBeenActivated) {
         if (observers.isEmpty()) {
             return;
         }
@@ -79,7 +79,7 @@ public class FlowDecompositionObserverList {
         Map<String, Double> results = referenceNodalInjectionComputer.run(networkMatrixIndexes.getNodeList());
 
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcFlows(results);
+            o.computedAcFlows(results, fallbackHasBeenActivated);
         }
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/ReferenceFlowComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/ReferenceFlowComputer.java
@@ -9,8 +9,8 @@ package com.powsybl.flow_decomposition;
 import com.powsybl.iidm.network.Branch;
 import com.powsybl.iidm.network.Identifiable;
 
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
  * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
  */
 class ReferenceFlowComputer {
-    Map<String, Double> run(Set<Branch> xnecList) {
+    Map<String, Double> run(Collection<Branch> xnecList) {
         return xnecList.stream()
             .collect(Collectors.toMap(
                 Identifiable::getId,

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.flow_decomposition;
+
+import com.powsybl.flow_decomposition.xnec_provider.XnecProviderByIds;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FlowDecompositionObserverTest {
+    private enum Event {
+        RUN_START, RUN_DONE, COMPUTING_BASE_CASE, COMPUTING_CONTINGENCY, COMPUTED_GLSK, COMPUTED_NET_POSITIONS, COMPUTED_NODAL_INJECTIONS_MATRIX, COMPUTED_PTDF_MATRIX, COMPUTED_PSDF_MATRIX, COMPUTED_AC_NODAL_INJECTIONS, COMPUTED_DC_NODAL_INJECTIONS, COMPUTED_AC_FLOWS, COMPUTED_DC_FLOWS,
+    }
+
+    private static final String BASE_CASE = "base-case";
+
+    /**
+     * ObserverReport gathers all observed events from the flow decomposition. It keeps the events occuring, and the
+     * matrices
+     */
+    private final class ObserverReport implements FlowDecompositionObserver {
+
+        private List<Event> events = new LinkedList<>();
+        private String currentContingency = null;
+        private ContingencyValue<List<Event>> eventsPerContingency = new ContingencyValue<>();
+        private Map<Country, Map<String, Double>> glsks;
+        private Map<Country, Double> netPositions;
+        private ContingencyValue<Map<String, Map<String, Double>>> nodalInjections = new ContingencyValue<>();
+        private ContingencyValue<Map<String, Map<String, Double>>> ptdfs = new ContingencyValue<>();
+        private ContingencyValue<Map<String, Map<String, Double>>> psdfs = new ContingencyValue<>();
+        private ContingencyValue<Map<String, Double>> acNodalInjections = new ContingencyValue<>();
+        private ContingencyValue<Map<String, Double>> dcNodalInjections = new ContingencyValue<>();
+        private ContingencyValue<Map<String, Double>> acFlows = new ContingencyValue<>();
+        private ContingencyValue<Map<String, Double>> dcFlows = new ContingencyValue<>();
+
+        public List<Event> allEvents() {
+            return events;
+        }
+
+        public List<Event> eventsForBaseCase() {
+            return eventsPerContingency.forBaseCase();
+        }
+
+        public List<Event> eventsForContingency(String contingencyId) {
+            return eventsPerContingency.forContingency(contingencyId);
+        }
+
+        @Override
+        public void runStart() {
+            addEvent(Event.RUN_START);
+        }
+
+        @Override
+        public void runDone() {
+            addEvent(Event.RUN_DONE);
+        }
+
+        @Override
+        public void computingBaseCase() {
+            currentContingency = BASE_CASE;
+            addEvent(Event.COMPUTING_BASE_CASE);
+        }
+
+        @Override
+        public void computingContingency(String contingencyId) {
+            currentContingency = contingencyId;
+            addEvent(Event.COMPUTING_CONTINGENCY);
+        }
+
+        @Override
+        public void computedGlsk(Map<Country, Map<String, Double>> glsks) {
+            addEvent(Event.COMPUTED_GLSK);
+            this.glsks = glsks;
+        }
+
+        @Override
+        public void computedNetPositions(Map<Country, Double> netPositions) {
+            addEvent(Event.COMPUTED_NET_POSITIONS);
+            this.netPositions = netPositions;
+        }
+
+        @Override
+        public void computedNodalInjectionsMatrix(Map<String, Map<String, Double>> nodalInjections) {
+            addEvent(Event.COMPUTED_NODAL_INJECTIONS_MATRIX);
+            this.nodalInjections.put(currentContingency, nodalInjections);
+        }
+
+        @Override
+        public void computedPtdfMatrix(Map<String, Map<String, Double>> pdtfMatrix) {
+            addEvent(Event.COMPUTED_PTDF_MATRIX);
+            this.ptdfs.put(currentContingency, pdtfMatrix);
+        }
+
+        @Override
+        public void computedPsdfMatrix(Map<String, Map<String, Double>> psdfMatrix) {
+            addEvent(Event.COMPUTED_PSDF_MATRIX);
+            this.psdfs.put(currentContingency, psdfMatrix);
+        }
+
+        @Override
+        public void computedAcNodalInjections(Map<String, Double> positions, boolean fallbackHasBeenActivated) {
+            addEvent(Event.COMPUTED_AC_NODAL_INJECTIONS);
+            this.acNodalInjections.put(currentContingency, positions);
+        }
+
+        @Override
+        public void computedDcNodalInjections(Map<String, Double> positions) {
+            addEvent(Event.COMPUTED_DC_NODAL_INJECTIONS);
+            this.dcNodalInjections.put(currentContingency, positions);
+        }
+
+        @Override
+        public void computedAcFlows(Map<String, Double> flows) {
+            addEvent(Event.COMPUTED_AC_FLOWS);
+            this.acFlows.put(currentContingency, flows);
+        }
+
+        @Override
+        public void computedDcFlows(Map<String, Double> flows) {
+            addEvent(Event.COMPUTED_DC_FLOWS);
+            this.dcFlows.put(currentContingency, flows);
+        }
+
+        private void addEvent(Event e) {
+            if (currentContingency != null) {
+                eventsPerContingency.putIfAbsent(currentContingency, new LinkedList<>());
+                eventsPerContingency.forContingency(currentContingency).add(e);
+            }
+            events.add(e);
+        }
+    }
+
+    @Test
+    void testNStateN1AndN2PostContingencyState() {
+        String networkFileName = "19700101_0000_FO4_UX1.uct";
+        String branchId = "DB000011 DF000011 1";
+        String contingencyElementId1 = "FB000011 FD000011 1";
+        String contingencyElementId2 = "FB000021 FD000021 1";
+        String contingencyId1 = "DD000011 DF000011 1";
+        String contingencyId2 = "FB000011 FD000011 1_FB000021 FD000021 1";
+
+        Network network = TestUtils.importNetwork(networkFileName);
+        Map<String, Set<String>> contingencies = Map.ofEntries(
+            Map.entry(contingencyId1, Set.of(contingencyId1)),
+            Map.entry(contingencyId2, Set.of(contingencyElementId1, contingencyElementId2)));
+        XnecProvider xnecProvider = XnecProviderByIds.builder()
+                                                     .addContingencies(contingencies)
+                                                     .addNetworkElementsAfterContingencies(
+                                                         Set.of(branchId),
+                                                         Set.of(contingencyId1, contingencyId2))
+                                                     .addNetworkElementsOnBasecase(Set.of(branchId))
+                                                     .build();
+        var flowDecompositionParameters = FlowDecompositionParameters.load();
+        FlowDecompositionComputer flowComputer = new FlowDecompositionComputer(flowDecompositionParameters);
+        var report = new ObserverReport();
+
+        flowComputer.addObserver(report);
+
+        flowComputer.run(xnecProvider, network);
+
+        assertEventsFired(report.allEvents(), Event.COMPUTED_GLSK, Event.COMPUTED_NET_POSITIONS);
+
+        assertEventsFired(
+            report.eventsForBaseCase(),
+            Event.COMPUTED_AC_FLOWS,
+            Event.COMPUTED_AC_NODAL_INJECTIONS,
+            Event.COMPUTED_DC_FLOWS,
+            Event.COMPUTED_DC_NODAL_INJECTIONS,
+            Event.COMPUTED_NODAL_INJECTIONS_MATRIX,
+            Event.COMPUTED_PTDF_MATRIX,
+            Event.COMPUTED_PSDF_MATRIX);
+
+        for (var contingencyId : List.of(contingencyId1, contingencyId2)) {
+            assertEventsFired(
+                report.eventsForContingency(contingencyId),
+                Event.COMPUTED_AC_FLOWS,
+                Event.COMPUTED_AC_NODAL_INJECTIONS,
+                Event.COMPUTED_DC_FLOWS,
+                Event.COMPUTED_DC_NODAL_INJECTIONS,
+                Event.COMPUTED_NODAL_INJECTIONS_MATRIX,
+                Event.COMPUTED_PTDF_MATRIX,
+                Event.COMPUTED_PSDF_MATRIX);
+        }
+
+        // Checking GLSK
+        assertEquals(Set.of(Country.BE, Country.DE, Country.FR), report.glsks.keySet());
+        assertEquals(Set.of("DB000011_generator", "DF000011_generator"), report.glsks.get(Country.DE).keySet());
+
+        // Checking net positions
+        assertEquals(Set.of(Country.BE, Country.DE, Country.FR), report.netPositions.keySet());
+
+        var xnecNodes = Set.of(
+            "BB000021_load",
+            "BF000011_generator",
+            "BF000021_load",
+            "DB000011_generator",
+            "DD000011_load",
+            "DF000011_generator",
+            "FB000021_generator",
+            "FB000022_load",
+            "FD000011_load",
+            "FF000011_generator",
+            "XES00011 FD000011 1",
+            "XNL00011 BB000011 1");
+
+        // Checking nodal injections
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            assertEquals(xnecNodes, report.nodalInjections.forContingency(contingencyId).keySet());
+            assertEquals(
+                Set.of("Allocated Flow", "Loop Flow from BE"),
+                report.nodalInjections.forContingency(contingencyId).get("BB000021_load").keySet());
+        }
+
+        // Checking PTDFs
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            var branches = Set.of(branchId);
+            assertEquals(branches, report.ptdfs.forContingency(contingencyId).keySet());
+            assertEquals(xnecNodes, report.ptdfs.forContingency(contingencyId).get(branchId).keySet());
+        }
+
+        // Checking PSDFs
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            var branches = Set.of(branchId);
+            var pstNodes = Set.of("BF000011 BF000012 1");
+            assertEquals(branches, report.psdfs.forContingency(contingencyId).keySet());
+            assertEquals(
+                pstNodes,
+                report.psdfs.forContingency(contingencyId).get(branchId).keySet(),
+                "contingency = " + contingencyId);
+        }
+
+        // Checking AC nodal injections
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            assertEquals(xnecNodes, report.acNodalInjections.forContingency(contingencyId).keySet());
+        }
+
+        // Checking DC nodal injections
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            assertEquals(xnecNodes, report.dcNodalInjections.forContingency(contingencyId).keySet());
+        }
+
+        var allBranches = Set.of(
+            "BB000011 BB000021 1",
+            "BB000011 BD000011 1",
+            "BB000011 BF000012 1",
+            "BB000021 BD000021 1",
+            "BB000021 BF000021 1",
+            "BD000011 BD000021 1",
+            "BD000011 BF000011 1",
+            "BD000021 BF000021 1",
+            "BF000011 BF000012 1",
+            "BF000011 BF000021 1",
+            "DB000011 DD000011 1",
+            "DB000011 DF000011 1",
+            "DD000011 DF000011 1",
+            "FB000011 FB000022 1",
+            "FB000011 FD000011 1",
+            "FB000011 FF000011 1",
+            "FB000021 FD000021 1",
+            "FD000011 FD000021 1",
+            "FD000011 FF000011 1",
+            "FD000011 FF000011 2",
+            "XBD00011 BD000011 1 + XBD00011 DB000011 1",
+            "XBD00012 BD000011 1 + XBD00012 DB000011 1",
+            "XBF00011 BF000011 1 + XBF00011 FB000011 1",
+            "XBF00021 BF000021 1 + XBF00021 FB000021 1",
+            "XBF00022 BF000021 1 + XBF00022 FB000022 1",
+            "XDF00011 DF000011 1 + XDF00011 FD000011 1");
+
+        // Checking AC flows
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            assertEquals(allBranches, report.acFlows.forContingency(contingencyId).keySet());
+        }
+
+        // Checking DC flows
+        for (var contingencyId : List.of(BASE_CASE, contingencyId1, contingencyId2)) {
+            assertEquals(allBranches, report.dcFlows.forContingency(contingencyId).keySet());
+        }
+    }
+
+    private void assertEventsFired(Collection<Event> firedEvents, Event... expectedEvents) {
+        var missing = new HashSet<Event>();
+        Collections.addAll(missing, expectedEvents);
+        missing.removeAll(firedEvents);
+        assertTrue(missing.isEmpty(), () -> "Missing events: " + missing.toString());
+    }
+
+    private static final class ContingencyValue<T> {
+        private Map<String, T> values = new HashMap<>();
+
+        public void put(String contingencyId, T value) {
+            values.put(contingencyId, value);
+        }
+
+        public void putIfAbsent(String contingencyId, T value) {
+            values.putIfAbsent(contingencyId, value);
+        }
+
+        public T forContingency(String contingencyId) {
+            return values.get(contingencyId);
+        }
+
+        public T forBaseCase() {
+            return values.get(BASE_CASE);
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No



**What kind of change does this PR introduce?**
This PR adds an Observer to the flow decomposition computation.
It is possible to attach an observer to be notified of computed matrices during the computation.
This helps building reports to understand the final results of such a computation.

**What is the current behavior?**
The flow decomposition is opaque.


**What is the new behavior (if this is a feature change)?**
The intermediate results of the algorithm are sent to the observers.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
I made sure having no observer (the default production behavior) would not be crippled by this new feature, especially because we need to transform the sparse matrices (internal model) to Maps. The current implementation would not convert these matrices in case there is no observer.