### PR TITLE
[Flow decomposition] Fix net position computation with dangling lines

### DIFF
--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
@@ -23,6 +23,13 @@ class NetPositionComputer {
     static Map<Country, Double> computeNetPositions(Network network) {
         Map<Country, Double> netPositions = new EnumMap<>(Country.class);
 
+        // TODO insert comment here
+        // TODO add this
+        network.getDanglingLineStream().forEach(danglingLine -> {
+            Country country = NetworkUtil.getTerminalCountry(danglingLine.getTerminal());
+            addLeavingFlow(netPositions, danglingLine, country);
+        });
+
         network.getLineStream().forEach(line -> {
             Country countrySide1 = NetworkUtil.getTerminalCountry(line.getTerminal1());
             Country countrySide2 = NetworkUtil.getTerminalCountry(line.getTerminal2());
@@ -33,15 +40,16 @@ class NetPositionComputer {
             addLeavingFlow(netPositions, line, countrySide2);
         });
 
-        network.getTieLineStream().forEach(line -> {
-            Country countrySide1 = NetworkUtil.getTerminalCountry(line.getTerminal1());
-            Country countrySide2 = NetworkUtil.getTerminalCountry(line.getTerminal2());
-            if (countrySide1.equals(countrySide2)) {
-                return;
-            }
-            addLeavingFlow(netPositions, line, countrySide1);
-            addLeavingFlow(netPositions, line, countrySide2);
-        });
+        // TODO remove this
+        //network.getTieLineStream().forEach(line -> {
+        //    Country countrySide1 = NetworkUtil.getTerminalCountry(line.getTerminal1());
+        //    Country countrySide2 = NetworkUtil.getTerminalCountry(line.getTerminal2());
+        //    if (countrySide1.equals(countrySide2)) {
+        //        return;
+        //    }
+        //    addLeavingFlow(netPositions, line, countrySide1);
+        //    addLeavingFlow(netPositions, line, countrySide2);
+        //});
 
         network.getHvdcLineStream().forEach(hvdcLine -> {
             Country countrySide1 = NetworkUtil.getTerminalCountry(hvdcLine.getConverterStation1().getTerminal());
@@ -75,6 +83,11 @@ class NetPositionComputer {
         netPositions.put(country, previousValue + getLeavingFlow(hvdcLine, country));
     }
 
+    private static void addLeavingFlow(Map<Country, Double> netPositions, DanglingLine danglingLine, Country country) {
+        Double previousValue = getPreviousValue(netPositions, country);
+        netPositions.put(country, previousValue + getLeavingFlow(danglingLine));
+    }
+
     private static double getLeavingFlow(Line line, Country country) {
         double flowSide1 = line.getTerminal1().isConnected() && !Double.isNaN(line.getTerminal1().getP()) ? line.getTerminal1().getP() : 0;
         double flowSide2 = line.getTerminal2().isConnected() && !Double.isNaN(line.getTerminal2().getP()) ? line.getTerminal2().getP() : 0;
@@ -94,5 +107,9 @@ class NetPositionComputer {
         double flowSide2 = hvdcLine.getConverterStation2().getTerminal().isConnected() && !Double.isNaN(hvdcLine.getConverterStation2().getTerminal().getP()) ? hvdcLine.getConverterStation2().getTerminal().getP() : 0;
         double directFlow = (flowSide1 - flowSide2) / 2;
         return country.equals(NetworkUtil.getTerminalCountry(hvdcLine.getConverterStation1().getTerminal())) ? directFlow : -directFlow;
+    }
+
+    private static double getLeavingFlow(DanglingLine danglingLine) {
+        return danglingLine.getTerminal().isConnected() && !Double.isNaN(danglingLine.getTerminal().getP()) ? danglingLine.getTerminal().getP() : 0;
     }
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
@@ -66,7 +66,7 @@ class NetPositionComputer {
     }
 
     private static void addLeavingFlow(Map<Country, Double> netPositions, DanglingLine danglingLine, Country country) {
-        Double previousValue = getPreviousValue(netPositions, country);
+        double previousValue = getPreviousValue(netPositions, country);
         netPositions.put(country, previousValue + getLeavingFlow(danglingLine));
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
@@ -23,8 +23,6 @@ class NetPositionComputer {
     static Map<Country, Double> computeNetPositions(Network network) {
         Map<Country, Double> netPositions = new EnumMap<>(Country.class);
 
-        // TODO insert comment here
-        // TODO add this
         network.getDanglingLineStream().forEach(danglingLine -> {
             Country country = NetworkUtil.getTerminalCountry(danglingLine.getTerminal());
             addLeavingFlow(netPositions, danglingLine, country);
@@ -39,17 +37,6 @@ class NetPositionComputer {
             addLeavingFlow(netPositions, line, countrySide1);
             addLeavingFlow(netPositions, line, countrySide2);
         });
-
-        // TODO remove this
-        //network.getTieLineStream().forEach(line -> {
-        //    Country countrySide1 = NetworkUtil.getTerminalCountry(line.getTerminal1());
-        //    Country countrySide2 = NetworkUtil.getTerminalCountry(line.getTerminal2());
-        //    if (countrySide1.equals(countrySide2)) {
-        //        return;
-        //    }
-        //    addLeavingFlow(netPositions, line, countrySide1);
-        //    addLeavingFlow(netPositions, line, countrySide2);
-        //});
 
         network.getHvdcLineStream().forEach(hvdcLine -> {
             Country countrySide1 = NetworkUtil.getTerminalCountry(hvdcLine.getConverterStation1().getTerminal());
@@ -73,11 +60,6 @@ class NetPositionComputer {
         netPositions.put(country, previousValue + getLeavingFlow(line, country));
     }
 
-    private static void addLeavingFlow(Map<Country, Double> netPositions, TieLine line, Country country) {
-        double previousValue = getPreviousValue(netPositions, country);
-        netPositions.put(country, previousValue + getLeavingFlow(line, country));
-    }
-
     private static void addLeavingFlow(Map<Country, Double> netPositions, HvdcLine hvdcLine, Country country) {
         double previousValue = getPreviousValue(netPositions, country);
         netPositions.put(country, previousValue + getLeavingFlow(hvdcLine, country));
@@ -89,13 +71,6 @@ class NetPositionComputer {
     }
 
     private static double getLeavingFlow(Line line, Country country) {
-        double flowSide1 = line.getTerminal1().isConnected() && !Double.isNaN(line.getTerminal1().getP()) ? line.getTerminal1().getP() : 0;
-        double flowSide2 = line.getTerminal2().isConnected() && !Double.isNaN(line.getTerminal2().getP()) ? line.getTerminal2().getP() : 0;
-        double directFlow = (flowSide1 - flowSide2) / 2;
-        return country.equals(NetworkUtil.getTerminalCountry(line.getTerminal1())) ? directFlow : -directFlow;
-    }
-
-    private static double getLeavingFlow(TieLine line, Country country) {
         double flowSide1 = line.getTerminal1().isConnected() && !Double.isNaN(line.getTerminal1().getP()) ? line.getTerminal1().getP() : 0;
         double flowSide2 = line.getTerminal2().isConnected() && !Double.isNaN(line.getTerminal2().getP()) ? line.getTerminal2().getP() : 0;
         double directFlow = (flowSide1 - flowSide2) / 2;

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionWithContingencyTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionWithContingencyTests.java
@@ -43,7 +43,7 @@ class FlowDecompositionWithContingencyTests {
         TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.isRescaleEnabled(), flowDecompositionResults);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
-        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -1269.932, -22.027);
+        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -1269.932, 31.943);
     }
 
     @Test
@@ -69,8 +69,8 @@ class FlowDecompositionWithContingencyTests {
         TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.isRescaleEnabled(), flowDecompositionResults);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
-        validateFlowDecompositionOnXnec(xnecId1, branchId, contingencyId1, decomposedFlowMap.get(xnecId1), -300.420, -15.496);
-        validateFlowDecompositionOnXnec(xnecId2, branchId, contingencyId2, decomposedFlowMap.get(xnecId2), -1269.932, -22.027);
+        validateFlowDecompositionOnXnec(xnecId1, branchId, contingencyId1, decomposedFlowMap.get(xnecId1), -300.420, 22.472);
+        validateFlowDecompositionOnXnec(xnecId2, branchId, contingencyId2, decomposedFlowMap.get(xnecId2), -1269.932, 31.943);
     }
 
     @Test
@@ -95,7 +95,7 @@ class FlowDecompositionWithContingencyTests {
         TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.isRescaleEnabled(), flowDecompositionResults);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
-        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -406.204, 3.329);
+        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -406.204, 48.362);
     }
 
     @Test
@@ -125,9 +125,9 @@ class FlowDecompositionWithContingencyTests {
         TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.isRescaleEnabled(), flowDecompositionResults);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
-        validateFlowDecompositionOnXnec(xnecId1, branchId, contingencyId1, decomposedFlowMap.get(xnecId1), -300.420, -15.496);
-        validateFlowDecompositionOnXnec(xnecId2, branchId, contingencyId2, decomposedFlowMap.get(xnecId2), -1269.932, -22.027);
-        validateFlowDecompositionOnXnec(xnecId3, branchId, contingencyId3, decomposedFlowMap.get(xnecId3), -406.204, 3.329);
+        validateFlowDecompositionOnXnec(xnecId1, branchId, contingencyId1, decomposedFlowMap.get(xnecId1), -300.420, 22.472);
+        validateFlowDecompositionOnXnec(xnecId2, branchId, contingencyId2, decomposedFlowMap.get(xnecId2), -1269.932, 31.943);
+        validateFlowDecompositionOnXnec(xnecId3, branchId, contingencyId3, decomposedFlowMap.get(xnecId3), -406.204, 48.362);
     }
 
     private static void validateFlowDecompositionOnXnec(String xnecId,

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NetPositionTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NetPositionTest.java
@@ -9,6 +9,7 @@ package com.powsybl.flow_decomposition;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.loadflow.LoadFlow;
+import com.powsybl.loadflow.LoadFlowParameters;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -57,4 +58,14 @@ class NetPositionTest {
         assertEquals(0.0, sumAllNetPositions, DOUBLE_TOLERANCE);
     }
 
+    @Test
+    void testUnboundedXnode() {
+        Network network = Network.read("NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_UNBOUNDED_XNODE.uct", getClass().getResourceAsStream("NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_UNBOUNDED_XNODE.uct"));
+        LoadFlow.run(network, new LoadFlowParameters().setDc(true));
+        Map<Country, Double> netPositions = NetPositionComputer.computeNetPositions(network);
+        assertEquals(100, netPositions.get(Country.FR), DOUBLE_TOLERANCE);
+        assertEquals(0, netPositions.get(Country.BE), DOUBLE_TOLERANCE);
+        double sumAllNetPositions = netPositions.values().stream().mapToDouble(Double::doubleValue).sum();
+        assertEquals(100, sumAllNetPositions, DOUBLE_TOLERANCE);
+    }
 }

--- a/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_UNBOUNDED_XNODE.uct
+++ b/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_UNBOUNDED_XNODE.uct
@@ -1,0 +1,20 @@
+##C 2007.05.01
+This is a test network with only two branches.
+Each branch is linking a generator with a  central load.
+Used to validate:
+- Basic network importer
+- XNEC automatic selection
+- GLSK automatic generation
+- Zone automatic extraction
+##N
+##ZFR
+FGEN1 11 GEN          0 3 400.00 0.00000 0.00000 -100.00 0.00000 1000.00 -1000.0 1000.00 -1000.0
+##ZBE
+BGEN2 11 GEN          0 2 400.00 0.00000 0.00000 -100.00 0.00000 1000.00 -1000.0 1000.00 -1000.0
+BLOAD 11 LOAD         0 0        100.000 0.00000 0.00000 0.00000
+##ZXX
+X     11 XNODE        0 0        100.000 0.00000 0.00000 0.00000 1000.00 -1000.0 1000.00 -1000.0
+##L
+FGEN1 11 BLOAD 11 1 0 1.0000 0.0500 0.000000    480 LINE
+BLOAD 11 BGEN2 11 1 0 1.0000 0.0500 0.000000    480 LINE
+BLOAD 11 X     11 1 0 1.0000 0.0500 0.000000    480 LINE


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
The flow decomposition was wrong when a network had some dangling lines.
This is caused by a bug in the net position computation.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
We fixed the net position computation with dangling line.
A test has been added.


**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
None


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Previous results of flow decomposition on network with dangling lines are wrong. 
