### PR TITLE
Fix scalable null sum

### DIFF
--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -81,15 +81,17 @@ public final class GlskPointScalableConverter {
                 throw new GlskException("In convert glskShiftKey business type not supported");
             }
             Double percentageSum = percentages.stream().mapToDouble(Double::doubleValue).sum();
-            shiftKeyPercentages.add(percentageSum);
 
             // each scalable needs to have a sum of percentages equal to 100%
             List<Double> normalizedPercentages;
             if (Math.abs(percentageSum) >= 1e-6) {
-                normalizedPercentages = percentages.stream().map(p -> p * 100. / percentageSum).toList();
+                Double finalPercentageSum = percentageSum;
+                normalizedPercentages = percentages.stream().map(p -> p * 100. / finalPercentageSum).toList();
             } else {
                 normalizedPercentages = percentages.stream().map(p -> 100. / percentages.size()).toList();
+                percentageSum = 0.;
             }
+            shiftKeyPercentages.add(percentageSum);
             // the limit of the scalables is the power they can reach, not how much they can be scaled by
             Double currentPower = scalables.stream().mapToDouble(scalable -> scalable.getSteadyStatePower(network, 1, Scalable.ScalingConvention.GENERATOR)).sum();
             shiftKeyScalables.add(Scalable.proportional(normalizedPercentages, scalables, -Double.MAX_VALUE, currentPower + glskShiftKey.getMaximumShift()));

--- a/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
+++ b/glsk/glsk-document-api/src/main/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverter.java
@@ -84,7 +84,12 @@ public final class GlskPointScalableConverter {
             shiftKeyPercentages.add(percentageSum);
 
             // each scalable needs to have a sum of percentages equal to 100%
-            List<Double> normalizedPercentages = percentages.stream().map(p -> p * 100 / percentageSum).toList();
+            List<Double> normalizedPercentages;
+            if (Math.abs(percentageSum) >= 1e-6) {
+                normalizedPercentages = percentages.stream().map(p -> p * 100. / percentageSum).toList();
+            } else {
+                normalizedPercentages = percentages.stream().map(p -> 100. / percentages.size()).toList();
+            }
             // the limit of the scalables is the power they can reach, not how much they can be scaled by
             Double currentPower = scalables.stream().mapToDouble(scalable -> scalable.getSteadyStatePower(network, 1, Scalable.ScalingConvention.GENERATOR)).sum();
             shiftKeyScalables.add(Scalable.proportional(normalizedPercentages, scalables, -Double.MAX_VALUE, currentPower + glskShiftKey.getMaximumShift()));

--- a/glsk/glsk-document-cim/src/test/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverterTest.java
+++ b/glsk/glsk-document-cim/src/test/java/com/powsybl/glsk/api/util/converters/GlskPointScalableConverterTest.java
@@ -257,4 +257,27 @@ class GlskPointScalableConverterTest {
         assertEquals(840., testNetwork.getLoad("FFR1AA1 _load").getP0(), DOUBLE_TOLERANCE); // 0.4 * 0.4 = 16 %
         assertEquals(760., testNetwork.getDanglingLine("BBE2AA1  XNODE_1B 1").getP0(), DOUBLE_TOLERANCE); // 0.4 * 0.6 = 24 %
     }
+
+    @Test
+    void testNullPercentageSum() {
+        GlskPoint glsk = CimGlskDocument.importGlsk(getResourceAsStream("/GlskB43ParticipationFactorGskLskZeroSum.xml")).getGlskPoints().get(0);
+        Scalable scalable = GlskPointScalableConverter.convert(testNetwork, glsk);
+
+        assertNotNull(scalable);
+        assertEquals(2000., testNetwork.getGenerator("FFR1AA1 _generator").getTargetP(), DOUBLE_TOLERANCE);
+        assertEquals(2000., testNetwork.getGenerator("FFR2AA1 _generator").getTargetP(), DOUBLE_TOLERANCE);
+        assertEquals(3000., testNetwork.getGenerator("FFR3AA1 _generator").getTargetP(), DOUBLE_TOLERANCE);
+        assertEquals(1000., testNetwork.getLoad("FFR1AA1 _load").getP0(), DOUBLE_TOLERANCE);
+        assertEquals(3500., testNetwork.getLoad("FFR2AA1 _load").getP0(), DOUBLE_TOLERANCE);
+        assertEquals(1500., testNetwork.getLoad("FFR3AA1 _load").getP0(), DOUBLE_TOLERANCE);
+
+        double done = scalable.scale(testNetwork, 500.);
+        assertEquals(500., done, DOUBLE_TOLERANCE);
+        assertEquals(2350., testNetwork.getGenerator("FFR1AA1 _generator").getTargetP(), DOUBLE_TOLERANCE); // 0.7 * 1.0 = 70 %
+        assertEquals(2150., testNetwork.getGenerator("FFR2AA1 _generator").getTargetP(), DOUBLE_TOLERANCE); // 0.3 * 1.0 = 30 %
+        assertEquals(3000., testNetwork.getGenerator("FFR3AA1 _generator").getTargetP(), DOUBLE_TOLERANCE); // untouched
+        assertEquals(1000., testNetwork.getLoad("FFR1AA1 _load").getP0(), DOUBLE_TOLERANCE); // 0.0 * 0.0 = 0 %
+        assertEquals(3500., testNetwork.getLoad("FFR2AA1 _load").getP0(), DOUBLE_TOLERANCE); // 0.0 * 0.0 = 0 %
+        assertEquals(1500., testNetwork.getLoad("FFR3AA1 _load").getP0(), DOUBLE_TOLERANCE); // untouched
+    }
 }

--- a/glsk/glsk-document-cim/src/test/resources/GlskB43ParticipationFactorGskLskZeroSum.xml
+++ b/glsk/glsk-document-cim/src/test/resources/GlskB43ParticipationFactorGskLskZeroSum.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GLSK_MarketDocument xmlns="urn:iec62325.351:tc57wg16:451-n:glskdocument:2:1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:iec62325.351:tc57wg16:451-n:glskdocument:2:1 iec62325-451-n-glsk_v2_1.xsd">
+  <mRID>49V000000000017G-20180829-F717</mRID>
+  <revisionNumber>1</revisionNumber>
+  <type>B22</type>
+  <process.processType>A49</process.processType>
+  <sender_MarketParticipant.mRID codingScheme="A01">49V000000000017G</sender_MarketParticipant.mRID>
+  <sender_MarketParticipant.marketRole.type>A36</sender_MarketParticipant.marketRole.type>
+  <receiver_MarketParticipant.mRID codingScheme="A01">10XDE-RWENET---W</receiver_MarketParticipant.mRID>
+  <receiver_MarketParticipant.marketRole.type>A04</receiver_MarketParticipant.marketRole.type>
+  <createdDateTime>2018-10-02T12:21:00Z</createdDateTime>
+  <status>
+    <value>A42</value>
+  </status>
+  <time_Period.timeInterval>
+    <start>2018-08-28T22:00Z</start>
+    <end>2018-08-29T22:00Z</end>
+  </time_Period.timeInterval>
+  <domain.mRID codingScheme="A01">10YDOM-REGION-1V</domain.mRID>
+  <TimeSeries>
+    <mRID>GLSK_B43_participation_factor</mRID>
+    <subject_Domain.mRID codingScheme="A01">10YFR-RTE------C</subject_Domain.mRID>
+    <curveType>A03</curveType>
+    <Period>
+      <timeInterval>
+        <start>2018-08-28T22:00Z</start>
+        <end>2018-08-29T22:00Z</end>
+      </timeInterval>
+      <resolution>PT60M</resolution>
+      <Point>
+        <position>1</position>
+        <SKBlock_TimeSeries>
+          <businessType>B43</businessType>
+          <mktPSRType.psrType>A04</mktPSRType.psrType>
+          <quantity.quantity>1.0</quantity.quantity>
+          <RegisteredResource>
+            <mRID codingScheme="A02">FFR1AA1 _generator</mRID>
+            <name>FFR1AA1 _generator</name>
+            <sK_ResourceCapacity.defaultCapacity>0.7</sK_ResourceCapacity.defaultCapacity>
+          </RegisteredResource>
+          <RegisteredResource>
+            <mRID codingScheme="A02">FFR2AA1 _generator</mRID>
+            <name>FFR2AA1 _generator</name>
+            <sK_ResourceCapacity.defaultCapacity>0.3</sK_ResourceCapacity.defaultCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+        <SKBlock_TimeSeries>
+          <businessType>B43</businessType>
+          <mktPSRType.psrType>A05</mktPSRType.psrType>
+          <quantity.quantity>0.0</quantity.quantity>
+          <RegisteredResource>
+            <mRID codingScheme="A02">FFR1AA1 _load</mRID>
+            <name>FFR1AA1 _load</name>
+            <sK_ResourceCapacity.defaultCapacity>0.0</sK_ResourceCapacity.defaultCapacity>
+          </RegisteredResource>
+          <RegisteredResource>
+            <mRID codingScheme="A02">FFR2AA1 _load</mRID>
+            <name>FFR2AA1 _load</name>
+            <sK_ResourceCapacity.defaultCapacity>0.0</sK_ResourceCapacity.defaultCapacity>
+          </RegisteredResource>
+        </SKBlock_TimeSeries>
+      </Point>
+    </Period>
+  </TimeSeries>
+</GLSK_MarketDocument>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
when the sum of percentages is null for a gsk/lsk, an error is thrown


**What is the new behavior (if this is a feature change)?**
The individual scalables will have a uniform percentage (all the same value with sum equal to 100).


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
