### PR TITLE
Update balance adjustment tests after load flow parameter to write slack bus changed to true by default

### DIFF
--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationImplDcTest.java
@@ -53,6 +53,7 @@ class BalanceComputationImplDcTest {
         parameters = new BalanceComputationParameters();
         parameters.getLoadFlowParameters().setDc(true);
         parameters.getLoadFlowParameters().setDistributedSlack(false);
+        parameters.getLoadFlowParameters().setWriteSlackBus(false);
         balanceComputationFactory = new BalanceComputationFactoryImpl();
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -44,10 +44,10 @@ class BalanceComputationSimpleDcTest {
     private LoadFlow.Runner loadFlowRunner;
     private Generator generatorFr;
     private Load loadFr;
-    private Branch branchFrBe1;
-    private Branch branchFrBe2;
-    private String initialState = "InitialState";
-    private String initialVariantNew = "InitialVariantNew";
+    private Branch<?> branchFrBe1;
+    private Branch<?> branchFrBe2;
+    private final String initialState = "InitialState";
+    private final String initialVariantNew = "InitialVariantNew";
 
     @BeforeEach
     void setUp() {
@@ -60,6 +60,7 @@ class BalanceComputationSimpleDcTest {
 
         parameters = new BalanceComputationParameters();
         parameters.getLoadFlowParameters().setDc(true);
+        parameters.getLoadFlowParameters().setWriteSlackBus(false);
 
         balanceComputationFactory = new BalanceComputationFactoryImpl();
 
@@ -246,11 +247,11 @@ class BalanceComputationSimpleDcTest {
         assertEquals(2, result.getIterationCount());
         assertEquals(initialState, simpleNetwork.getVariantManager().getWorkingVariantId());
 
-        loadFlowRunner.run(simpleNetwork, initialVariantNew, computationManager, new LoadFlowParameters());
+        loadFlowRunner.run(simpleNetwork, initialVariantNew, computationManager, parameters.getLoadFlowParameters());
         assertEquals(1300, countryAreaFR.create(simpleNetwork).getNetPosition(), 0.0001);
         assertEquals(-1300, countryAreaBE.create(simpleNetwork).getNetPosition(), 0.0001);
 
-        loadFlowRunner.run(simpleNetwork, initialState, computationManager, new LoadFlowParameters());
+        loadFlowRunner.run(simpleNetwork, initialState, computationManager, parameters.getLoadFlowParameters());
         assertEquals(1200, countryAreaFR.create(simpleNetwork).getNetPosition(), 0.0001);
         assertEquals(-1200, countryAreaBE.create(simpleNetwork).getNetPosition(), 0.0001);
     }
@@ -272,7 +273,7 @@ class BalanceComputationSimpleDcTest {
         assertEquals(5, result.getIterationCount());
         assertEquals(initialState, simpleNetwork.getVariantManager().getWorkingVariantId());
 
-        loadFlowRunner.run(simpleNetwork, initialState, computationManager, new LoadFlowParameters());
+        loadFlowRunner.run(simpleNetwork, initialState, computationManager, parameters.getLoadFlowParameters());
         assertEquals(1200, countryAreaFR.create(simpleNetwork).getNetPosition(), 0.0001);
         assertEquals(-1200, countryAreaBE.create(simpleNetwork).getNetPosition(), 0.0001);
 
@@ -308,7 +309,7 @@ class BalanceComputationSimpleDcTest {
         BalanceComputationAssert.assertReportEquals("/unbalancedNetworkReport.txt", reportNode);
     }
 
-    private abstract class AbstractLoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowProvider {
+    private static abstract class AbstractLoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowProvider {
         @Override
         public String getName() {
             return "test load flow";

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -309,7 +309,7 @@ class BalanceComputationSimpleDcTest {
         BalanceComputationAssert.assertReportEquals("/unbalancedNetworkReport.txt", reportNode);
     }
 
-    private static abstract class AbstractLoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowProvider {
+    private abstract static class AbstractLoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowProvider {
         @Override
         public String getName() {
             return "test load flow";

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/extension/ExtendedBalanceComputationTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/extension/ExtendedBalanceComputationTest.java
@@ -53,6 +53,7 @@ class ExtendedBalanceComputationTest {
         parameters = new BalanceComputationParameters();
         parameters.getLoadFlowParameters().setDc(true);
         parameters.getLoadFlowParameters().setDistributedSlack(false);
+        parameters.getLoadFlowParameters().setWriteSlackBus(false);
         balanceComputationFactory = new ExtendedBalanceComputationFactoryImpl();
 
         loadFlowRunner = new LoadFlow.Runner(new OpenLoadFlowProvider(new DenseMatrixFactory()));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Update tests


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Unit tests in balances-adjustment module rely on default load low parameters. 
Default value of load flow parameter for `writeSlackBus` was `false` in previous versions.
The default value has changed to `true`.


**What is the new behavior (if this is a feature change)?**
For the balance computation and related unit tests, we configure load flow exactly the same way it was, with `writeSlackBus` set to `false`.
Individual calls to load flow outside the balance computation have been modified to use the same load flow parameters used in balance computation.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
