### PR TITLE
Update emf tests after changes in tie line export

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,22 +20,20 @@ jobs:
     - name: print environment
       run: env
 
+    - name: Checkout sources
+      uses: actions/checkout@v1
+
     - name: Checkout powsybl-core branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-core
         ref: refs/heads/main
-        path: ../powsybl-core
 
     - name: Checkout powsybl-open-loadflow branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-open-loadflow
         ref: refs/heads/report_v2
-        path: ../powsybl-open-loadflow
-
-    - name: Checkout sources
-      uses: actions/checkout@v1
 
     - name: Set up JDK 17
       uses: actions/setup-java@v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,10 +45,10 @@ jobs:
         java-version: 17
 
     - name: Build and install powsybl-core with Maven
-      run: mvn --batch-mode -DskipTests=true --file ./powsybl-core/pom.xml
+      run: mvn --batch-mode -DskipTests=true --file ./powsybl-core/pom.xml install
 
     - name: Build and install powsybl-open-loadflow with Maven
-      run: mvn --batch-mode -DskipTests=true --file ./powsybl-open-loadflow/pom.xml
+      run: mvn --batch-mode -DskipTests=true --file ./powsybl-open-loadflow/pom.xml install
 
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-core
-        ref: refs/heads/main
+        ref: refs/heads/cgmes_export_tielines_as_danglingLines
         path: powsybl-core
 
     - name: Checkout powsybl-open-loadflow branch

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -52,16 +52,16 @@ jobs:
 
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'
-      run: mvn --batch-mode -Pjacoco install
+      run: mvn --batch-mode -Pjacoco --file ./main/pom.xml install
 
     - name: Build with Maven
       if: matrix.os != 'ubuntu-latest'
-      run: mvn --batch-mode install
+      run: mvn --batch-mode --file ./main/pom.xml install
 
     - name: Run SonarCloud analysis
       if: matrix.os == 'ubuntu-latest'
       run: >
-        mvn --batch-mode -DskipTests sonar:sonar
+        mvn --batch-mode -DskipTests  --file ./main/pom.xml sonar:sonar
         -Dsonar.host.url=https://sonarcloud.io
         -Dsonar.organization=powsybl-ci-github
         -Dsonar.projectKey=com.powsybl:powsybl-entsoe

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,19 +21,23 @@ jobs:
       run: env
 
     - name: Checkout sources
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
+      with:
+        path: main
 
     - name: Checkout powsybl-core branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-core
         ref: refs/heads/main
+        path: powsybl-core
 
     - name: Checkout powsybl-open-loadflow branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-open-loadflow
         ref: refs/heads/report_v2
+        path: powsybl-open-loadflow
 
     - name: Set up JDK 17
       uses: actions/setup-java@v1
@@ -41,10 +45,10 @@ jobs:
         java-version: 17
 
     - name: Build and install powsybl-core with Maven
-      run: ./mvnw --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml
+      run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml
 
     - name: Build and install powsybl-open-loadflow with Maven
-      run: ./mvnw --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml
+      run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml
 
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,17 +17,22 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
+    - name: print environment
+      run: env
+
     - name: Checkout powsybl-core branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-core
         ref: refs/heads/main
+        path: powsybl-core
 
     - name: Checkout powsybl-open-loadflow branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-open-loadflow
         ref: refs/heads/reporter_v2
+        path: powsybl-open-loadflow
 
     - name: Checkout sources
       uses: actions/checkout@v1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,6 +17,18 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
+    - name: Checkout powsybl-core branch
+      uses: actions/checkout@v4
+      with:
+        repository: powsybl/powsybl-core
+        ref: refs/heads/main
+
+    - name: Checkout powsybl-open-loadflow branch
+      uses: actions/checkout@v4
+      with:
+        repository: powsybl/powsybl-open-loadflow
+        ref: refs/heads/reporter_v2
+
     - name: Checkout sources
       uses: actions/checkout@v1
 
@@ -24,6 +36,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 17
+
+    - name: Build and install powsybl-core with Maven
+      run: ./mvnw --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml
+
+    - name: Build and install powsybl-open-loadflow with Maven
+      run: ./mvnw --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml
 
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,10 +45,10 @@ jobs:
         java-version: 17
 
     - name: Build and install powsybl-core with Maven
-      run: mvn --batch-mode -DskipTests=true --file ../powsybl-core/pom.xml
+      run: mvn --batch-mode -DskipTests=true --file ./powsybl-core/pom.xml
 
     - name: Build and install powsybl-open-loadflow with Maven
-      run: mvn --batch-mode -DskipTests=true --file ../powsybl-open-loadflow/pom.xml
+      run: mvn --batch-mode -DskipTests=true --file ./powsybl-open-loadflow/pom.xml
 
     - name: Build with Maven
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,14 +25,14 @@ jobs:
       with:
         repository: powsybl/powsybl-core
         ref: refs/heads/main
-        path: powsybl-core
+        path: ../powsybl-core
 
     - name: Checkout powsybl-open-loadflow branch
       uses: actions/checkout@v4
       with:
         repository: powsybl/powsybl-open-loadflow
-        ref: refs/heads/reporter_v2
-        path: powsybl-open-loadflow
+        ref: refs/heads/report_v2
+        path: ../powsybl-open-loadflow
 
     - name: Checkout sources
       uses: actions/checkout@v1

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputation.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputation.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.balances_adjustment.balance_computation;
 
-import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.iidm.network.Network;
 
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +22,6 @@ public interface BalanceComputation {
 
     CompletableFuture<BalanceComputationResult> run(Network network, String workingStateId, BalanceComputationParameters parameters);
 
-    CompletableFuture<BalanceComputationResult> run(Network network, String workingStateId, BalanceComputationParameters parameters, Reporter reporter);
+    CompletableFuture<BalanceComputationResult> run(Network network, String workingStateId, BalanceComputationParameters parameters, ReportNode reportNode);
 
 }

--- a/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/Reports.java
+++ b/balances-adjustment/src/main/java/com/powsybl/balances_adjustment/util/Reports.java
@@ -6,13 +6,11 @@
  */
 package com.powsybl.balances_adjustment.util;
 
-import com.powsybl.commons.reporter.Report;
-import com.powsybl.commons.reporter.Reporter;
-import com.powsybl.commons.reporter.TypedValue;
+import com.powsybl.commons.report.ReportNode;
+import com.powsybl.commons.report.TypedValue;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Map;
 
 /**
  * @author George Budau {@literal <george.budau at artelys.com>}
@@ -25,62 +23,58 @@ public final class Reports {
     private Reports() {
     }
 
-    public static void reportScaling(Reporter reporter, String areaName, double offset, double done) {
-        reporter.report(Report.builder()
-                .withKey("areaScaling")
-                .withDefaultMessage("Scaling for area ${areaName}: offset=${offset}, done=${done}")
-                .withValue(AREA_NAME, areaName)
-                .withValue("offset", offset)
-                .withValue("done", done)
+    public static void reportScaling(ReportNode reportNode, String areaName, double offset, double done) {
+        reportNode.newReportNode().withMessageTemplate("areaScaling",
+                        "Scaling for area ${areaName}: offset=${offset}, done=${done}")
+                .withUntypedValue(AREA_NAME, areaName)
+                .withUntypedValue("offset", offset)
+                .withUntypedValue("done", done)
                 .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
+                .add();
     }
 
-    public static void reportLfStatus(Reporter reporter, int networkNumCc, int networkNumSc, String status, TypedValue severity) {
-        reporter.report(Report.builder()
-                .withKey("lfStatus")
-                .withDefaultMessage("Network CC${networkNumCc} SC${networkNumSc} Load flow complete with status '${status}'")
-                .withValue("networkNumCc", networkNumCc)
-                .withValue("networkNumSc", networkNumSc)
-                .withValue("status", status)
+    public static void reportLfStatus(ReportNode reportNode, int networkNumCc, int networkNumSc, String status, TypedValue severity) {
+        reportNode.newReportNode().withMessageTemplate("lfStatus",
+                        "Network CC${networkNumCc} SC${networkNumSc} Load flow complete with status '${status}'")
+                .withUntypedValue("networkNumCc", networkNumCc)
+                .withUntypedValue("networkNumSc", networkNumSc)
+                .withUntypedValue("status", status)
                 .withSeverity(severity)
-                .build());
+                .add();
     }
 
-    public static void reportAreaMismatch(Reporter reporter, String areaName, double mismatch, double target, double balance) {
-        reporter.report(Report.builder()
-                .withKey("areaMismatch")
-                .withDefaultMessage("Mismatch for area ${areaName}: ${mismatch} (target=${target}, balance=${balance})")
-                .withValue(AREA_NAME, areaName)
-                .withValue("mismatch", mismatch)
-                .withValue("target", target)
-                .withValue("balance", balance)
+    public static void reportAreaMismatch(ReportNode reportNode, String areaName, double mismatch, double target, double balance) {
+        reportNode.newReportNode().withMessageTemplate("areaMismatch",
+                        "Mismatch for area ${areaName}: ${mismatch} (target=${target}, balance=${balance})")
+                .withUntypedValue(AREA_NAME, areaName)
+                .withUntypedValue("mismatch", mismatch)
+                .withUntypedValue("target", target)
+                .withUntypedValue("balance", balance)
                 .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
+                .add();
     }
 
-    public static void reportBalancedAreas(Reporter reporter, List<String> networkAreasName, int iterationCount) {
-        reporter.report(Report.builder()
-                .withKey("balancedAreas")
-                .withDefaultMessage("Areas ${networkAreasName} are balanced after ${iterationCount} iterations")
-                .withValue("networkAreasName", networkAreasName.toString())
-                .withValue("iterationCount", iterationCount)
+    public static void reportBalancedAreas(ReportNode reportNode, List<String> networkAreasName, int iterationCount) {
+        reportNode.newReportNode().withMessageTemplate("balancedAreas",
+                        "Areas ${networkAreasName} are balanced after ${iterationCount} iterations")
+                .withUntypedValue("networkAreasName", networkAreasName.toString())
+                .withUntypedValue("iterationCount", iterationCount)
                 .withSeverity(TypedValue.INFO_SEVERITY)
-                .build());
+                .add();
     }
 
-    public static void reportUnbalancedAreas(Reporter reporter, int iteration, BigDecimal totalMismatch) {
-        reporter.report(Report.builder()
-                .withKey("unbalancedAreas")
-                .withDefaultMessage("Areas are unbalanced after ${iteration} iterations, total mismatch is ${totalMismatch}")
-                .withValue(ITERATION, iteration)
-                .withValue("totalMismatch", totalMismatch.toString())
+    public static void reportUnbalancedAreas(ReportNode reportNode, int iteration, BigDecimal totalMismatch) {
+        reportNode.newReportNode().withMessageTemplate("unbalancedAreas",
+                "Areas are unbalanced after ${iteration} iterations, total mismatch is ${totalMismatch}")
+                .withUntypedValue(ITERATION, iteration)
+                .withUntypedValue("totalMismatch", totalMismatch.toString())
                 .withSeverity(TypedValue.ERROR_SEVERITY)
-                .build());
+                .add();
     }
 
-    public static Reporter createBalanceComputationIterationReporter(Reporter reporter, int iteration) {
-        return reporter.createSubReporter("balanceComputation", "Balance Computation iteration '${iteration}'",
-                Map.of(ITERATION, new TypedValue(iteration, TypedValue.UNTYPED)));
+    public static ReportNode createBalanceComputationIterationReporter(ReportNode reportNode, int iteration) {
+        return reportNode.newReportNode().withMessageTemplate("balanceComputation", "Balance Computation iteration '${iteration}'")
+                .withUntypedValue(ITERATION, iteration)
+                .add();
     }
 }

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/balance_computation/BalanceComputationSimpleDcTest.java
@@ -8,8 +8,7 @@ package com.powsybl.balances_adjustment.balance_computation;
 
 import com.powsybl.balances_adjustment.util.BalanceComputationAssert;
 import com.powsybl.balances_adjustment.util.CountryAreaFactory;
-import com.powsybl.commons.reporter.Reporter;
-import com.powsybl.commons.reporter.ReporterModel;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.computation.ComputationManager;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.iidm.modification.scalable.Scalable;
@@ -110,7 +109,7 @@ class BalanceComputationSimpleDcTest {
         LoadFlowProvider loadFlowProviderMock = new AbstractLoadFlowProviderMock() {
 
             @Override
-            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, Reporter reporter) {
+            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode) {
                 generatorFr.getTerminal().setP(3000);
                 loadFr.getTerminal().setP(1800);
 
@@ -142,7 +141,7 @@ class BalanceComputationSimpleDcTest {
         LoadFlowProvider loadFlowProviderMock = new AbstractLoadFlowProviderMock() {
 
             @Override
-            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, Reporter reporter) {
+            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode) {
                 generatorFr.getTerminal().setP(3000);
                 loadFr.getTerminal().setP(1800);
 
@@ -177,7 +176,7 @@ class BalanceComputationSimpleDcTest {
         LoadFlowProvider loadFlowProviderMock = new AbstractLoadFlowProviderMock() {
 
             @Override
-            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, Reporter reporter) {
+            public CompletableFuture<LoadFlowResult> run(Network network, ComputationManager computationManager, String workingVariantId, LoadFlowParameters parameters, ReportNode reportNode) {
                 generatorFr.getTerminal().setP(3000);
                 loadFr.getTerminal().setP(1800);
                 branchFrBe1.getTerminal1().setP(-516);
@@ -291,9 +290,9 @@ class BalanceComputationSimpleDcTest {
 
         BalanceComputation balanceComputation = balanceComputationFactory.create(areas, loadFlowRunner, computationManager);
 
-        ReporterModel reporter = new ReporterModel("testBalancedNetworkReport", "Test balanced network report");
-        balanceComputation.run(simpleNetwork, simpleNetwork.getVariantManager().getWorkingVariantId(), parameters, reporter).join();
-        BalanceComputationAssert.assertReportEquals("/balancedNetworkReport.txt", reporter);
+        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testBalancedNetworkReport", "Test balanced network report").build();
+        balanceComputation.run(simpleNetwork, simpleNetwork.getVariantManager().getWorkingVariantId(), parameters, reportNode).join();
+        BalanceComputationAssert.assertReportEquals("/balancedNetworkReport.txt", reportNode);
     }
 
     @Test
@@ -304,9 +303,9 @@ class BalanceComputationSimpleDcTest {
 
         BalanceComputation balanceComputation = balanceComputationFactory.create(areas, loadFlowRunner, computationManager);
 
-        ReporterModel reporter = new ReporterModel("testUnbalancedNetworkReport", "Test unbalanced network report");
-        balanceComputation.run(simpleNetwork, simpleNetwork.getVariantManager().getWorkingVariantId(), parameters, reporter).join();
-        BalanceComputationAssert.assertReportEquals("/unbalancedNetworkReport.txt", reporter);
+        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("testUnbalancedNetworkReport", "Test unbalanced network report").build();
+        balanceComputation.run(simpleNetwork, simpleNetwork.getVariantManager().getWorkingVariantId(), parameters, reportNode).join();
+        BalanceComputationAssert.assertReportEquals("/unbalancedNetworkReport.txt", reportNode);
     }
 
     private abstract class AbstractLoadFlowProviderMock extends AbstractNoSpecificParametersLoadFlowProvider {

--- a/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/BalanceComputationAssert.java
+++ b/balances-adjustment/src/test/java/com/powsybl/balances_adjustment/util/BalanceComputationAssert.java
@@ -7,7 +7,7 @@
 package com.powsybl.balances_adjustment.util;
 
 import com.google.common.io.ByteStreams;
-import com.powsybl.commons.reporter.ReporterModel;
+import com.powsybl.commons.report.ReportNode;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,13 +25,13 @@ public final class BalanceComputationAssert {
     private BalanceComputationAssert() {
     }
 
-    public static void assertReportEquals(String refResourceName, ReporterModel reporter) throws IOException {
-        assertReportEquals(BalanceComputationAssert.class.getResourceAsStream(refResourceName), reporter);
+    public static void assertReportEquals(String refResourceName, ReportNode reportNode) throws IOException {
+        assertReportEquals(BalanceComputationAssert.class.getResourceAsStream(refResourceName), reportNode);
     }
 
-    public static void assertReportEquals(InputStream ref, ReporterModel reporter) throws IOException {
+    public static void assertReportEquals(InputStream ref, ReportNode reportNode) throws IOException {
         StringWriter sw = new StringWriter();
-        reporter.export(sw);
+        reportNode.print(sw);
 
         String refLogExport = normalizeLineSeparator(new String(ByteStreams.toByteArray(ref), StandardCharsets.UTF_8));
         String logExport = normalizeLineSeparator(sw.toString());

--- a/balances-adjustment/src/test/resources/balanceComputationParametersWithExtension.json
+++ b/balances-adjustment/src/test/resources/balanceComputationParametersWithExtension.json
@@ -12,7 +12,7 @@
     "twtSplitShuntAdmittance" : false,
     "shuntCompensatorVoltageControlOn" : false,
     "readSlackBus" : true,
-    "writeSlackBus" : false,
+    "writeSlackBus" : true,
     "dc" : false,
     "distributedSlack" : true,
     "balanceType" : "PROPORTIONAL_TO_GENERATION_P_MAX",

--- a/balances-adjustment/src/test/resources/balancedNetworkReport.txt
+++ b/balances-adjustment/src/test/resources/balancedNetworkReport.txt
@@ -1,31 +1,31 @@
 + Test balanced network report
-  + Balance Computation iteration '0'
-    + Scaling
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=4000.0 MW, active load=4000.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: 100.0 (target=1300.0, balance=1200.0)
-       Mismatch for area BE: -100.0 (target=-1300.0, balance=-1200.0)
-  + Balance Computation iteration '1'
-    + Scaling
-       Scaling for area FR: offset=100.0, done=100.0
-       Scaling for area BE: offset=-100.0, done=-100.0
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=4000.0 MW, active load=4000.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: 0.0 (target=1300.0, balance=1300.0)
-       Mismatch for area BE: 0.0 (target=-1300.0, balance=-1300.0)
-  + Status
-     Areas [FR, BE] are balanced after 2 iterations
+   + Balance Computation iteration '0'
+      Scaling
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=4000.0 MW, active load=4000.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: 100.0 (target=1300.0, balance=1200.0)
+         Mismatch for area BE: -100.0 (target=-1300.0, balance=-1200.0)
+   + Balance Computation iteration '1'
+      + Scaling
+         Scaling for area FR: offset=100.0, done=100.0
+         Scaling for area BE: offset=-100.0, done=-100.0
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=4000.0 MW, active load=4000.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: 0.0 (target=1300.0, balance=1300.0)
+         Mismatch for area BE: 0.0 (target=-1300.0, balance=-1300.0)
+   + Status
+      Areas [FR, BE] are balanced after 2 iterations

--- a/balances-adjustment/src/test/resources/unbalancedNetworkReport.txt
+++ b/balances-adjustment/src/test/resources/unbalancedNetworkReport.txt
@@ -1,76 +1,76 @@
 + Test unbalanced network report
-  + Balance Computation iteration '0'
-    + Scaling
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=4000.0 MW, active load=4000.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: 100.0 (target=1300.0, balance=1200.0)
-       Mismatch for area BE: -200.0 (target=-1400.0, balance=-1200.0)
-  + Balance Computation iteration '1'
-    + Scaling
-       Scaling for area FR: offset=100.0, done=100.0
-       Scaling for area BE: offset=-200.0, done=-200.0
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=3940.0 MW, active load=4040.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
-       Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
-  + Balance Computation iteration '2'
-    + Scaling
-       Scaling for area FR: offset=50.0, done=50.0
-       Scaling for area BE: offset=-250.0, done=-250.0
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=3880.0 MW, active load=4080.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
-       Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
-  + Balance Computation iteration '3'
-    + Scaling
-       Scaling for area FR: offset=0.0, done=0.0
-       Scaling for area BE: offset=-300.0, done=-300.0
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=3820.0 MW, active load=4120.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
-       Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
-  + Balance Computation iteration '4'
-    + Scaling
-       Scaling for area FR: offset=-50.0, done=-50.0
-       Scaling for area BE: offset=-350.0, done=-350.0
-    + Load flow on network 'TestNetwork'
-      + Network CC0 SC0
-         DC load flow completed (status=true)
-        + Post loading processing
-           Network has 3 buses and 3 branches
-           Network balance: active generation=3760.0 MW, active load=4160.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
-    + Checking load flow status
-       Network CC0 SC0 Load flow complete with status 'CONVERGED'
-    + Mismatch
-       Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
-       Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
-  + Status
-     Areas are unbalanced after 5 iterations, total mismatch is 5000.00
+   + Balance Computation iteration '0'
+      Scaling
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=4000.0 MW, active load=4000.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: 100.0 (target=1300.0, balance=1200.0)
+         Mismatch for area BE: -200.0 (target=-1400.0, balance=-1200.0)
+   + Balance Computation iteration '1'
+      + Scaling
+         Scaling for area FR: offset=100.0, done=100.0
+         Scaling for area BE: offset=-200.0, done=-200.0
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=3940.0 MW, active load=4040.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
+         Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
+   + Balance Computation iteration '2'
+      + Scaling
+         Scaling for area FR: offset=50.0, done=50.0
+         Scaling for area BE: offset=-250.0, done=-250.0
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=3880.0 MW, active load=4080.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
+         Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
+   + Balance Computation iteration '3'
+      + Scaling
+         Scaling for area FR: offset=0.0, done=0.0
+         Scaling for area BE: offset=-300.0, done=-300.0
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=3820.0 MW, active load=4120.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
+         Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
+   + Balance Computation iteration '4'
+      + Scaling
+         Scaling for area FR: offset=-50.0, done=-50.0
+         Scaling for area BE: offset=-350.0, done=-350.0
+      + Load flow on network 'TestNetwork'
+         + Network CC0 SC0
+            + Network info
+               Network has 3 buses and 3 branches
+               Network balance: active generation=3760.0 MW, active load=4160.0 MW, reactive generation=0.0 MVar, reactive load=0.0 MVar
+            DC load flow completed (status=true)
+      + Checking load flow status
+         Network CC0 SC0 Load flow complete with status 'CONVERGED'
+      + Mismatch
+         Mismatch for area FR: -50.0 (target=1300.0, balance=1350.0)
+         Mismatch for area BE: -50.0 (target=-1400.0, balance=-1350.0)
+   + Status
+      Areas are unbalanced after 5 iterations, total mismatch is 5000.00

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/AbstractSensitivityAnalyser.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/AbstractSensitivityAnalyser.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.flow_decomposition;
 
-import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.computation.local.LocalComputationManager;
 import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyContext;
@@ -79,7 +79,7 @@ abstract class AbstractSensitivityAnalyser {
             sensitivityVariableSets,
             sensitivityAnalysisParameters,
             LocalComputationManager.getDefault(),
-            Reporter.NO_OP
+            ReportNode.NO_OP
         );
     }
 }

--- a/glsk/glsk-quality-check-ucte/src/main/java/com/powsybl/glsk/ucte/quality_check/GlskQualityProcessor.java
+++ b/glsk/glsk-quality-check-ucte/src/main/java/com/powsybl/glsk/ucte/quality_check/GlskQualityProcessor.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.glsk.ucte.quality_check;
 
-import com.powsybl.commons.reporter.Reporter;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.glsk.ucte.UcteGlskDocument;
 import com.powsybl.iidm.network.Network;
 
@@ -21,12 +21,12 @@ public final class GlskQualityProcessor {
     private GlskQualityProcessor() {
     }
 
-    public static void process(String cgmName, InputStream cgmIs, InputStream glskIs, Instant localDate, Reporter reporter) {
-        process(UcteGlskDocument.importGlsk(glskIs), Network.read(cgmName, cgmIs), localDate, reporter);
+    public static void process(String cgmName, InputStream cgmIs, InputStream glskIs, Instant localDate, ReportNode reportNode) {
+        process(UcteGlskDocument.importGlsk(glskIs), Network.read(cgmName, cgmIs), localDate, reportNode);
     }
 
-    public static void process(UcteGlskDocument ucteGlskDocument, Network network, Instant instant, Reporter reporter) {
+    public static void process(UcteGlskDocument ucteGlskDocument, Network network, Instant instant, ReportNode reportNode) {
         GlskQualityCheckInput input = new GlskQualityCheckInput(ucteGlskDocument, network, instant);
-        GlskQualityCheck.gskQualityCheck(input, reporter);
+        GlskQualityCheck.gskQualityCheck(input, reportNode);
     }
 }

--- a/glsk/glsk-quality-check-ucte/src/test/java/com/powsybl/glsk/ucte/quality_check/GlskQualityProcessorTest.java
+++ b/glsk/glsk-quality-check-ucte/src/test/java/com/powsybl/glsk/ucte/quality_check/GlskQualityProcessorTest.java
@@ -6,8 +6,7 @@
  */
 package com.powsybl.glsk.ucte.quality_check;
 
-import com.powsybl.commons.reporter.Report;
-import com.powsybl.commons.reporter.ReporterModel;
+import com.powsybl.commons.report.ReportNode;
 import com.powsybl.glsk.ucte.UcteGlskDocument;
 import com.powsybl.iidm.network.Network;
 import org.junit.jupiter.api.Test;
@@ -33,28 +32,28 @@ class GlskQualityProcessorTest {
     void qualityCheckWithCorrectValue() {
         UcteGlskDocument ucteGlskDocument = UcteGlskDocument.importGlsk(getResourceAsInputStream(COUNTRYTEST));
         Network network = Network.read("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
-        ReporterModel reporter = new ReporterModel("defaultTask", "defaultName");
-        GlskQualityProcessor.process(ucteGlskDocument, network, Instant.parse("2016-07-28T23:30:00Z"), reporter);
+        ReportNode reportNode = ReportNode.newRootReportNode().withMessageTemplate("defaultTask", "defaultName").build();
+        GlskQualityProcessor.process(ucteGlskDocument, network, Instant.parse("2016-07-28T23:30:00Z"), reportNode);
 
-        assertTrue(reporter.getReports().isEmpty());
+        assertTrue(reportNode.getChildren().isEmpty());
     }
 
     @Test
     void qualityCheckWithError1() {
         UcteGlskDocument ucteGlskDocument = UcteGlskDocument.importGlsk(getResourceAsInputStream(FIRST_ERROR));
         Network network = Network.read("testCase.xiidm", getClass().getResourceAsStream("/testCase.xiidm"));
-        ReporterModel reporter = new ReporterModel("defaultTask", "defaultName");
+        ReportNode reporter = ReportNode.newRootReportNode().withMessageTemplate("defaultTask", "defaultName").build();
         GlskQualityProcessor.process(ucteGlskDocument, network, Instant.parse("2016-07-28T23:30:00Z"), reporter);
 
-        assertEquals(1, reporter.getReports().size());
-        Report r = reporter.getReports().stream().findFirst().get();
-        assertEquals("GLSK node is not found in CGM", r.getDefaultMessage());
-        assertEquals("FFR2AA2 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).toString());
-        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).toString());
+        assertEquals(1, reporter.getChildren().size());
+        ReportNode r = reporter.getChildren().stream().findFirst().get();
+        assertEquals("GLSK node is not found in CGM", r.getMessage());
+        assertEquals("FFR2AA2 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).get().toString());
+        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).get().toString());
         //Get unique TSO count in logs
-        assertEquals(1, reporter.getReports().stream().filter(rep -> rep.getValue(GlskQualityCheck.TSO_KEY).toString().equals("10YFR-RTE------C")).count());
+        assertEquals(1, reporter.getChildren().stream().filter(rep -> rep.getValue(GlskQualityCheck.TSO_KEY).get().toString().equals("10YFR-RTE------C")).count());
         //Get log count for RTE
-        assertEquals(1, reporter.getReports().stream().map(rep -> rep.getValue(GlskQualityCheck.TSO_KEY).toString()).distinct().count());
+        assertEquals(1, reporter.getChildren().stream().map(rep -> rep.getValue(GlskQualityCheck.TSO_KEY).get().toString()).distinct().count());
 
     }
 
@@ -62,42 +61,42 @@ class GlskQualityProcessorTest {
     void qualityCheckWithError2() {
         UcteGlskDocument ucteGlskDocument = UcteGlskDocument.importGlsk(getResourceAsInputStream(COUNTRYTEST));
         Network network = Network.read("testCase_error_2.xiidm", getClass().getResourceAsStream("/testCase_error_2.xiidm"));
-        ReporterModel reporter = new ReporterModel("defaultTask", "defaultName");
+        ReportNode reporter = ReportNode.newRootReportNode().withMessageTemplate("defaultTask", "defaultName").build();
         GlskQualityProcessor.process(ucteGlskDocument, network, Instant.parse("2016-07-28T23:30:00Z"), reporter);
 
-        assertEquals(1, reporter.getReports().size());
-        Report r = reporter.getReports().stream().findFirst().get();
-        assertEquals("GLSK node is present but has no running Generator or Load", r.getDefaultMessage());
-        assertEquals("FFR2AA1 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).toString());
-        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).toString());
+        assertEquals(1, reporter.getChildren().size());
+        ReportNode r = reporter.getChildren().stream().findFirst().get();
+        assertEquals("GLSK node is present but has no running Generator or Load", r.getMessage());
+        assertEquals("FFR2AA1 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).get().toString());
+        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).get().toString());
     }
 
     @Test
     void qualityCheckWithError3() {
         UcteGlskDocument ucteGlskDocument = UcteGlskDocument.importGlsk(getResourceAsInputStream(COUNTRYTEST));
         Network network = Network.read("testCase_error_3.xiidm", getClass().getResourceAsStream("/testCase_error_3.xiidm"));
-        ReporterModel reporter = new ReporterModel("defaultTask", "defaultName");
+        ReportNode reporter = ReportNode.newRootReportNode().withMessageTemplate("defaultTask", "defaultName").build();
         GlskQualityProcessor.process(ucteGlskDocument, network, Instant.parse("2016-07-28T23:30:00Z"), reporter);
 
-        assertEquals(1, reporter.getReports().size());
-        Report r = reporter.getReports().stream().findFirst().get();
-        assertEquals("GLSK node is connected to an island", r.getDefaultMessage());
-        assertEquals("FFR2AA1 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).toString());
-        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).toString());
+        assertEquals(1, reporter.getChildren().size());
+        ReportNode r = reporter.getChildren().stream().findFirst().get();
+        assertEquals("GLSK node is connected to an island", r.getMessage());
+        assertEquals("FFR2AA1 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).get().toString());
+        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).get().toString());
     }
 
     @Test
     void qualityCheckLoadNotConnected() {
         UcteGlskDocument ucteGlskDocument = UcteGlskDocument.importGlsk(getResourceAsInputStream(COUNTRYTEST));
         Network network = Network.read("testCase_error_load_not_connected.xiidm", getClass().getResourceAsStream("/testCase_error_load_not_connected.xiidm"));
-        ReporterModel reporter = new ReporterModel("defaultTask", "defaultName");
+        ReportNode reporter = ReportNode.newRootReportNode().withMessageTemplate("defaultTask", "defaultName").build();
         GlskQualityProcessor.process(ucteGlskDocument, network, Instant.parse("2016-07-28T23:30:00Z"), reporter);
 
-        assertEquals(1, reporter.getReports().size());
-        Report r = reporter.getReports().stream().findFirst().get();
-        assertEquals("GLSK node is connected to an island", r.getDefaultMessage());
-        assertEquals("FFR2AA1 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).toString());
-        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).toString());
+        assertEquals(1, reporter.getChildren().size());
+        ReportNode r = reporter.getChildren().stream().findFirst().get();
+        assertEquals("GLSK node is connected to an island", r.getMessage());
+        assertEquals("FFR2AA1 ", r.getValue(GlskQualityCheck.NODE_ID_KEY).get().toString());
+        assertEquals("10YFR-RTE------C", r.getValue(GlskQualityCheck.TSO_KEY).get().toString());
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
 
     <properties>
         <java.version>17</java.version>
-        <powsyblcore.version>6.2.0</powsyblcore.version>
-        <powsyblopenloadflow.version>1.7.0</powsyblopenloadflow.version>
+        <powsyblcore.version>6.3.0-SNAPSHOT</powsyblcore.version>
+        <powsyblopenloadflow.version>1.8.0-SNAPSHOT</powsyblopenloadflow.version>
         <sonar.coverage.jacoco.xmlReportPaths>
             ../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,
             ../../distribution-entsoe/target/site/jacoco-aggregate/jacoco.xml,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Update tests


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Previously, when a Common Grid Model (CGM) was exported as a single network the tie lines were exported as a single equipment.
The change introduced in https://github.com/powsybl/powsybl-core/pull/2619 update the export of CGM, keeping in the export the two ACLSs that are inside a tie line.


**What is the new behavior (if this is a feature change)?**
The unit test that checked the CGM export converted the tie lines to regular lines in the original network (the "expected" value of the tests) to be able to compare it with the "actual" exported CGM without errors.
This change is not required anymore.
When the CGM is exported as a single network the (p0, q0) values of the dangling lines inside tie lines are not relevant (as the whole tie line will be exported and re-imported).

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
