### PR TITLE
[Flow decomposition] Observer, NetworkUtil and Losses compensator improvements

### DIFF
--- a/docs/flow_decomposition/algorithm-description.md
+++ b/docs/flow_decomposition/algorithm-description.md
@@ -33,6 +33,15 @@ compensated at both sides proportionally to the resistance of each half line.
 
 ## Nodal Injections partitioning
 
+> **_NOTE:_** In PowSyBl terminology, nodal injections are injection connectables that 
+> - are not paired dangling lines, 
+> - are connected to the network,
+> - are in the main synchronous component (for sensitivity computation reasons),
+> - are not a bus bar section (because of a lack of reference injection),
+> - are not shunt compensator or static var compensator (for sensitivity computation reasons).
+
+> **_NOTE:_** In PowSyBl terminology, xnodes are unpaired dangling lines connected to the network and in the main synchronous component. 
+
 In order to distinguish internal/loop flows and allocated flows, the nodal injections in each zone must de decomposed in two parts:
 - Nodal injections for allocated flows
 - Nodal injections for loop flows and internal flows
@@ -63,6 +72,16 @@ where:
 
 ## Sensitivity analysis
 
+> **_NOTE:_** In PowSyBl terminology, only two windings transformers are considered. PSTs must:
+> - be connected to the network,
+> - have a phase tap changer,
+> - have a neutral step on the phase tap changer,
+> - have a bus at each terminal,
+> - be connected to the main synchronous component.
+> Therefore, three windings transformers are not supported. 
+
+> **_NOTE:_** Each element of the sensitivity computation must be connected to the main synchronous component (variables (injections) and functions (branches)). 
+
 In order to assess the linear impact (implied by the DC approximation) of each nodal injection and phase shift transformer
 on the network elements' flow, a sensitivity analysis is run.
 
@@ -89,7 +108,7 @@ where:
 - $\mathrm{F}_\mathrm{PST}$ is the vector of the network element PST (phase shift transformer) flow,
 - $\mathrm{F}_\mathrm{X}$ is the vector of the network element xnode flow,
 - $\mathrm{AM}$ is the allocation matrix, which associates each injection to its zone. $\mathrm{AM}_{ij}$ = 1 if node i is in zone j, 0 otherwise,
-- $\mathrm{\Delta}_\mathrm{PST}$ is the phase shift transformers angle vector,
+- $\mathrm{\Delta}_\mathrm{PST}$ is the phase shift transformers angle vector. The neutral tap position of each PST is used to compute this difference.
 
 ## Flow parts rescaling
 

--- a/flow-decomposition/pom.xml
+++ b/flow-decomposition/pom.xml
@@ -14,9 +14,14 @@
     <description>Implementation of ACER methodology for flow decomposition</description>
 
     <dependencies>
+        <!-- Compile dependencies -->
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-glsk-document-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
@@ -28,21 +33,64 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-glsk-document-api</artifactId>
+            <artifactId>powsybl-sensitivity-analysis-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-sensitivity-analysis-api</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>${commonscsv.version}</version>
         </dependency>
         <dependency>
             <groupId>org.ejml</groupId>
             <artifactId>ejml-all</artifactId>
             <version>${ejml.version}</version>
         </dependency>
+        <!-- Runtime dependencies -->
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-csv</artifactId>
-            <version>${commonscsv.version}</version>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-serde</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-open-loadflow</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-ucte-converter</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-cgmes-conformity</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-cgmes-conversion</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
@@ -56,53 +104,12 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-iidm-impl</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-iidm-serde</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-cgmes-conversion</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-cgmes-conformity</artifactId>
+            <artifactId>powsybl-iidm-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-triple-store-impl-rdf4j</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-open-loadflow</artifactId>
-            <version>${powsyblopenloadflow.version}</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-ucte-converter</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.jimfs</groupId>
-            <artifactId>jimfs</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-config-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlow.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlow.java
@@ -60,7 +60,7 @@ public class DecomposedFlow {
     }
 
     public String getId() {
-        return NetworkUtil.getXnecId(contingencyId, branchId);
+        return getXnecId(contingencyId, branchId);
     }
 
     public Country getCountry1() {
@@ -139,5 +139,9 @@ public class DecomposedFlow {
         localDecomposedFlowMap.put(INTERNAL_COLUMN_NAME, getInternalFlow());
         localDecomposedFlowMap.putAll(loopFlowsMap);
         return localDecomposedFlowMap;
+    }
+
+    public static String getXnecId(String contingencyId, String branchId) {
+        return contingencyId.isEmpty() ? branchId : String.format("%s_%s", branchId, contingencyId);
     }
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -107,24 +107,24 @@ public class FlowDecompositionObserverList {
         }
     }
 
-    public void computedAcNodalInjections(NetworkMatrixIndexes networkMatrixIndexes, boolean fallbackHasBeenActivated) {
+    public void computedAcNodalInjections(Network network, boolean fallbackHasBeenActivated) {
         if (observers.isEmpty()) {
             return;
         }
 
-        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(networkMatrixIndexes.getNodeList());
+        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
 
         for (FlowDecompositionObserver o : observers) {
             o.computedAcNodalInjections(results, fallbackHasBeenActivated);
         }
     }
 
-    public void computedDcNodalInjections(NetworkMatrixIndexes networkMatrixIndexes) {
+    public void computedDcNodalInjections(Network network) {
         if (observers.isEmpty()) {
             return;
         }
 
-        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(networkMatrixIndexes.getNodeList());
+        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
 
         for (FlowDecompositionObserver o : observers) {
             o.computedDcNodalInjections(results);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
@@ -77,7 +77,7 @@ public class FlowDecompositionResults {
         void build(DecomposedFlowRescaler decomposedFlowRescaler) {
             allocatedAndLoopFlowsMatrix.toMap()
                 .forEach((branchId, decomposedFlow) -> {
-                    String xnecId = NetworkUtil.getXnecId(contingencyId, branchId);
+                    String xnecId = DecomposedFlow.getXnecId(contingencyId, branchId);
                     decomposedFlowMap.put(xnecId, createDecomposedFlow(branchId, decomposedFlow, decomposedFlowRescaler));
                 });
         }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/LossesCompensator.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/LossesCompensator.java
@@ -18,10 +18,12 @@ import java.util.stream.Stream;
  *
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
 class LossesCompensator {
     private final double epsilon;
     private Integer networkHash;
+    public static final String LOSSES_ID_PREFIX = "LOSSES ";
 
     LossesCompensator(double epsilon) {
         this.epsilon = epsilon;
@@ -33,7 +35,7 @@ class LossesCompensator {
     }
 
     static String getLossesId(String id) {
-        return String.format("LOSSES %s", id);
+        return LOSSES_ID_PREFIX + id;
     }
 
     public void run(Network network) {
@@ -58,39 +60,17 @@ class LossesCompensator {
 
     private void compensateLossesOnBranches(Network network) {
         network.getBranchStream()
-            .filter(this::hasBuses)
-            .filter(this::hasP0s)
+            .filter(branch -> branch.getTerminal1().isConnected() || branch.getTerminal2().isConnected())
             .forEach(branch -> compensateLossesOnBranch(network, branch));
-    }
-
-    private boolean hasBus(Terminal terminal) {
-        return terminal.getBusBreakerView().getBus() != null;
-    }
-
-    private boolean hasBuses(Branch<?> branch) {
-        return hasBus(branch.getTerminal1()) && hasBus(branch.getTerminal2());
-    }
-
-    private boolean hasP0(Terminal terminal) {
-        return !Double.isNaN(terminal.getP());
-    }
-
-    private boolean hasP0s(Branch<?> branch) {
-        return hasP0(branch.getTerminal1()) && hasP0(branch.getTerminal2());
     }
 
     private static void addZeroMWLossesLoad(Network network, String busId) {
         String lossesId = getLossesId(busId);
         Bus bus = network.getBusBreakerView().getBus(busId);
         switch (bus.getVoltageLevel().getTopologyKind()) {
-            case BUS_BREAKER:
-                addZeroMWLossesLoadForBusBreakerTopology(bus, lossesId);
-                return;
-            case NODE_BREAKER:
-                addZeroMWLossesLoadForNodeTopology(bus, lossesId);
-                return;
-            default:
-                throw new PowsyblException("This topology is not managed by the loss compensation.");
+            case BUS_BREAKER -> addZeroMWLossesLoadForBusBreakerTopology(bus, lossesId);
+            case NODE_BREAKER -> addZeroMWLossesLoadForNodeBreakerTopology(bus, lossesId);
+            default -> throw new PowsyblException("Topology not supported by loss compensation.");
         }
     }
 
@@ -100,10 +80,11 @@ class LossesCompensator {
             .setBus(bus.getId())
             .setP0(0)
             .setQ0(0)
+            .setFictitious(true)
             .add();
     }
 
-    private static void addZeroMWLossesLoadForNodeTopology(Bus bus, String lossesId) {
+    private static void addZeroMWLossesLoadForNodeBreakerTopology(Bus bus, String lossesId) {
         VoltageLevel voltageLevel = bus.getVoltageLevel();
         VoltageLevel.NodeBreakerView nodeBreakerView = voltageLevel.getNodeBreakerView();
         int nodeNum = nodeBreakerView.getMaximumNodeIndex() + 1;
@@ -116,12 +97,13 @@ class LossesCompensator {
             .setNode(nodeNum)
             .setP0(0)
             .setQ0(0)
+            .setFictitious(true)
             .add();
     }
 
     private void compensateLossesOnBranch(Network network, Branch<?> branch) {
-        if (branch instanceof TieLine) {
-            compensateLossesOnTieLine(network, (TieLine) branch);
+        if (branch instanceof TieLine tieLine) {
+            compensateLossesOnTieLine(network, tieLine);
         } else {
             Terminal sendingTerminal = getSendingTerminal(branch);
             double losses = branch.getTerminal1().getP() + branch.getTerminal2().getP();
@@ -144,13 +126,26 @@ class LossesCompensator {
     }
 
     private void updateLoadForLossesOnTerminal(Network network, Terminal terminal, double losses) {
-        if (Math.abs(losses) > epsilon) {
+        if (losses > epsilon) {
             Load load = network.getLoad(getLossesId(terminal.getBusBreakerView().getBus().getId()));
             load.setP0(load.getP0() + losses);
         }
     }
 
     private Terminal getSendingTerminal(Branch<?> branch) {
-        return branch.getTerminal1().getP() > 0 ? branch.getTerminal1() : branch.getTerminal2();
+        Terminal terminal1 = branch.getTerminal1();
+        Terminal terminal2 = branch.getTerminal2();
+
+        // if only one terminal is connected, that is the sending terminal
+        if (!(terminal1.isConnected() && terminal2.isConnected())) {
+            return terminal1.isConnected() ? terminal1 : terminal2;
+        }
+
+        // terminal with greater P is the sending terminal
+        if (terminal1.getP() >= terminal2.getP()) {
+            return terminal1;
+        } else {
+            return terminal2;
+        }
     }
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 /**
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
- * @author Hugo Schindler{@literal <hugo.schindler@rte-france.com>}
+ * @author Hugo Schindler{@literal <hugo.schindler at rte-france.com>}
  */
 class NetPositionComputer {
     Map<Country, Double> run(Network network) {

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetworkMatrixIndexes.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetworkMatrixIndexes.java
@@ -10,13 +10,9 @@ import com.powsybl.iidm.network.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 /**
- * @author Hugo Schindler{@literal <hugo.schindler@rte-france.com>}
+ * @author Hugo Schindler{@literal <hugo.schindler at rte-france.com>}
  * @author Sebastien Murgey{@literal <sebastien.murgey at rte-france.com>}
  */
 class NetworkMatrixIndexes {
@@ -31,13 +27,13 @@ class NetworkMatrixIndexes {
 
     NetworkMatrixIndexes(Network network, List<Branch> xnecList) {
         this.xnecList = xnecList;
-        nodeList = getNodeList(network);
+        nodeList = NetworkUtil.getNodeList(network);
         nodeIdList = getNodeIdList(nodeList);
-        pstList = getPstIdList(network);
-        xnecIndex = getXnecIndex(this.xnecList);
+        pstList = NetworkUtil.getPstIdList(network);
+        xnecIndex = NetworkUtil.getIndex(getXnecIdList(this.xnecList));
         nodeIndex = NetworkUtil.getIndex(nodeIdList);
         pstIndex = NetworkUtil.getIndex(pstList);
-        xnodeList = getXNodeList(network);
+        xnodeList = NetworkUtil.getXNodeList(network);
     }
 
     List<Branch> getXnecList() {
@@ -76,74 +72,11 @@ class NetworkMatrixIndexes {
         return xnodeList;
     }
 
-    private List<Injection<?>> getNodeList(Network network) {
-        return getAllNetworkInjections(network)
-                .filter(this::isNotPairedDanglingLine)
-                .filter(this::isInjectionConnected)
-                .filter(this::isInjectionInMainSynchronousComponent)
-                .filter(this::managedInjectionTypes)
-                .collect(Collectors.toList());
-    }
-
-    private boolean managedInjectionTypes(Injection<?> injection) {
-        return !(injection instanceof BusbarSection || injection instanceof ShuntCompensator || injection instanceof StaticVarCompensator); // TODO Remove this fix once the active power computation after a DC load flow is fixed in OLF
-    }
-
-    private Stream<Injection<?>> getAllNetworkInjections(Network network) {
-        return network.getConnectableStream()
-            .filter(Injection.class::isInstance)
-            .map(connectable -> (Injection<?>) connectable);
-    }
-
-    private boolean isInjectionConnected(Injection<?> injection) {
-        return injection.getTerminal().isConnected();
-    }
-
-    private boolean isNotPairedDanglingLine(Injection<?> injection) {
-        return !(injection instanceof DanglingLine && ((DanglingLine) injection).isPaired());
-    }
-
-    private boolean isInjectionInMainSynchronousComponent(Injection<?> injection) {
-        return NetworkUtil.isTerminalInMainSynchronousComponent(injection.getTerminal());
-    }
-
     private List<String> getNodeIdList(List<Injection<?>> nodeList) {
-        return nodeList.stream()
-            .map(Injection::getId)
-            .collect(Collectors.toList());
+        return nodeList.stream().map(Injection::getId).toList();
     }
 
-    private List<String> getPstIdList(Network network) {
-        return network.getTwoWindingsTransformerStream()
-            .filter(this::isPst)
-            .filter(this::hasNeutralStep)
-            .map(Identifiable::getId)
-            .collect(Collectors.toList());
-    }
-
-    private boolean isPst(TwoWindingsTransformer twt) {
-        return twt.getPhaseTapChanger() != null;
-    }
-
-    private boolean hasNeutralStep(TwoWindingsTransformer pst) {
-        return pst.getPhaseTapChanger().getNeutralStep().isPresent();
-    }
-
-    private Map<String, Integer> getXnecIndex(List<Branch> xnecList) {
-        return IntStream.range(0, xnecList.size())
-            .boxed()
-            .collect(Collectors.toMap(
-                i -> xnecList.get(i).getId(),
-                Function.identity()
-            ));
-    }
-
-    private List<Injection<?>> getXNodeList(Network network) {
-        return network.getDanglingLineStream()
-                .filter(dl -> !dl.isPaired())
-                .filter(this::isInjectionConnected)
-                .filter(this::isInjectionInMainSynchronousComponent)
-                .map(danglingLine -> (Injection<?>) danglingLine)
-                .collect(Collectors.toList());
+    private List<String> getXnecIdList(List<Branch> xnecList) {
+        return xnecList.stream().map(Identifiable::getId).toList();
     }
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetworkUtil.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetworkUtil.java
@@ -11,24 +11,38 @@ import com.powsybl.iidm.network.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
- * @author Hugo Schindler{@literal <hugo.schindler@rte-france.com>}
+ * @author Hugo Schindler{@literal <hugo.schindler at rte-france.com>}
  * @author Sebastien Murgey{@literal <sebastien.murgey at rte-france.com>}
  */
 public final class NetworkUtil {
     static final String LOOP_FLOWS_COLUMN_PREFIX = "Loop Flow from";
 
     private NetworkUtil() {
-        throw new AssertionError("Utility class should not be instantiated");
+        // Utility class
+    }
+
+    public static String getLoopFlowIdFromCountry(Network network, String identifiableId) {
+        Identifiable<?> identifiable = network.getIdentifiable(identifiableId);
+        if (identifiable instanceof Injection<?> injection) {
+            return getLoopFlowIdFromCountry(getInjectionCountry(injection));
+        }
+        throw new PowsyblException(String.format("Identifiable %s must be an Injection", identifiableId));
     }
 
     public static String getLoopFlowIdFromCountry(Country country) {
         return String.format("%s %s", LOOP_FLOWS_COLUMN_PREFIX, country.toString());
+    }
+
+    public static Country getInjectionCountry(Injection<?> injection) {
+        return getTerminalCountry(injection.getTerminal());
     }
 
     public static Country getTerminalCountry(Terminal terminal) {
@@ -40,37 +54,23 @@ public final class NetworkUtil {
         Substation substation = optionalSubstation.get();
         Optional<Country> optionalCountry = substation.getCountry();
         if (optionalCountry.isEmpty()) {
-            throw new PowsyblException(String.format("Substation %s does not have country property" +
+            throw new PowsyblException(String.format("Substation %s does not have country property " +
                     "needed for the algorithm.", substation.getId()));
         }
         return optionalCountry.get();
     }
 
-    static String getLoopFlowIdFromCountry(Network network, String identifiableId) {
-        Identifiable<?> identifiable = network.getIdentifiable(identifiableId);
-        if (identifiable instanceof Injection) {
-            return getLoopFlowIdFromCountry(getInjectionCountry((Injection<?>) identifiable));
-        }
-        throw new PowsyblException(String.format("Identifiable %s must be an Injection", identifiableId));
-    }
-
-    static Map<String, Integer> getIndex(List<String> idList) {
+    public static Map<String, Integer> getIndex(List<String> idList) {
         return IntStream.range(0, idList.size())
             .boxed()
-            .collect(Collectors.toMap(
-                idList::get,
-                Function.identity()
-            ));
-    }
-
-    public static Country getInjectionCountry(Injection<?> injection) {
-        return getTerminalCountry(injection.getTerminal());
+            .collect(Collectors.toMap(idList::get, Function.identity()));
     }
 
     public static List<Branch> getAllValidBranches(Network network) {
         return network.getBranchStream()
             .filter(NetworkUtil::isConnected)
-            .filter(NetworkUtil::isInMainSynchronousComponent) // TODO Is connectedCompenent enough ?
+            .filter(NetworkUtil::hasABusToEachTerminal)
+            .filter(NetworkUtil::isInMainSynchronousComponent)
             .collect(Collectors.toList());
     }
 
@@ -78,16 +78,81 @@ public final class NetworkUtil {
         return branch.getTerminal1().isConnected() && branch.getTerminal2().isConnected();
     }
 
+    private static boolean hasABusToEachTerminal(Branch branch) {
+        return hasABusInBusBreakerView(branch.getTerminal1()) && hasABusInBusBreakerView(branch.getTerminal2());
+    }
+
+    private static boolean hasABusInBusBreakerView(Terminal terminal1) {
+        return Objects.nonNull(terminal1.getBusBreakerView().getBus());
+    }
+
     private static boolean isInMainSynchronousComponent(Branch<?> branch) {
         return isTerminalInMainSynchronousComponent(branch.getTerminal1())
             && isTerminalInMainSynchronousComponent(branch.getTerminal2());
     }
 
-    static boolean isTerminalInMainSynchronousComponent(Terminal terminal) {
+    private static boolean isTerminalInMainSynchronousComponent(Terminal terminal) {
+        // Sensitivity analysis does not work outside synchronous component...
         return terminal.getBusBreakerView().getBus().isInMainSynchronousComponent();
     }
 
-    static String getXnecId(String contingencyId, String branchId) {
-        return contingencyId.isEmpty() ? branchId : String.format("%s_%s", branchId, contingencyId);
+    public static List<Injection<?>> getNodeList(Network network) {
+        return getAllNetworkInjections(network)
+            .filter(NetworkUtil::isNotPairedDanglingLine)
+            .filter(NetworkUtil::isInjectionConnected)
+            .filter(NetworkUtil::isInjectionInMainSynchronousComponent)
+            .filter(NetworkUtil::hasReferenceInjections)
+            .filter(NetworkUtil::isValidInjectionsForSensitivityComputation)
+            .toList();
+    }
+
+    public static List<Injection<?>> getXNodeList(Network network) {
+        return network.getDanglingLineStream()
+            .filter(NetworkUtil::isNotPairedDanglingLine)
+            .filter(NetworkUtil::isInjectionConnected)
+            .filter(NetworkUtil::isInjectionInMainSynchronousComponent)
+            .map(danglingLine -> (Injection<?>) danglingLine)
+            .collect(Collectors.toList());
+    }
+
+    private static Stream<Injection<?>> getAllNetworkInjections(Network network) {
+        return network.getConnectableStream()
+            .filter(Injection.class::isInstance)
+            .map(connectable -> (Injection<?>) connectable);
+    }
+
+    private static boolean isNotPairedDanglingLine(Injection<?> injection) {
+        return !(injection instanceof DanglingLine danglingLine && danglingLine.isPaired());
+    }
+
+    private static boolean isInjectionConnected(Injection<?> injection) {
+        return injection.getTerminal().isConnected();
+    }
+
+    private static boolean isInjectionInMainSynchronousComponent(Injection<?> injection) {
+        return isTerminalInMainSynchronousComponent(injection.getTerminal());
+    }
+
+    private static boolean hasReferenceInjections(Injection<?> injection) {
+        return !(injection instanceof BusbarSection);
+    }
+
+    private static boolean isValidInjectionsForSensitivityComputation(Injection<?> injection) {
+        return !(injection instanceof ShuntCompensator || injection instanceof StaticVarCompensator);
+    }
+
+    public static List<String> getPstIdList(Network network) {
+        return network.getTwoWindingsTransformerStream()
+            .filter(NetworkUtil::isConnected)
+            .filter(PhaseTapChangerHolder::hasPhaseTapChanger)
+            .filter(NetworkUtil::hasNeutralStep)
+            .filter(NetworkUtil::hasABusToEachTerminal)
+            .filter(NetworkUtil::isInMainSynchronousComponent)
+            .map(Identifiable::getId)
+            .toList();
+    }
+
+    private static boolean hasNeutralStep(TwoWindingsTransformer pst) {
+        return pst.getPhaseTapChanger().getNeutralStep().isPresent();
     }
 }

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
@@ -44,20 +44,20 @@ class FlowDecompositionObserverTest {
      * ObserverReport gathers all observed events from the flow decomposition. It keeps the events occuring, and the
      * matrices
      */
-    private final class ObserverReport implements FlowDecompositionObserver {
+    private static final class ObserverReport implements FlowDecompositionObserver {
 
-        private List<Event> events = new LinkedList<>();
+        private final List<Event> events = new LinkedList<>();
         private String currentContingency = null;
-        private ContingencyValue<List<Event>> eventsPerContingency = new ContingencyValue<>();
+        private final ContingencyValue<List<Event>> eventsPerContingency = new ContingencyValue<>();
         private Map<Country, Map<String, Double>> glsks;
         private Map<Country, Double> netPositions;
-        private ContingencyValue<Map<String, Map<String, Double>>> nodalInjections = new ContingencyValue<>();
-        private ContingencyValue<Map<String, Map<String, Double>>> ptdfs = new ContingencyValue<>();
-        private ContingencyValue<Map<String, Map<String, Double>>> psdfs = new ContingencyValue<>();
-        private ContingencyValue<Map<String, Double>> acNodalInjections = new ContingencyValue<>();
-        private ContingencyValue<Map<String, Double>> dcNodalInjections = new ContingencyValue<>();
-        private ContingencyValue<Map<String, Double>> acFlows = new ContingencyValue<>();
-        private ContingencyValue<Map<String, Double>> dcFlows = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Map<String, Double>>> nodalInjections = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Map<String, Double>>> ptdfs = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Map<String, Double>>> psdfs = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Double>> acNodalInjections = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Double>> dcNodalInjections = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Double>> acFlows = new ContingencyValue<>();
+        private final ContingencyValue<Map<String, Double>> dcFlows = new ContingencyValue<>();
 
         public List<Event> allEvents() {
             return events;
@@ -329,15 +329,33 @@ class FlowDecompositionObserverTest {
         assertTrue(reportRemoved.allEvents().isEmpty());
     }
 
+    @Test
+    void testObserverWithEnableLossesCompensation() {
+        String networkFileName = "19700101_0000_FO4_UX1.uct";
+        String branchId = "DB000011 DF000011 1";
+        Network network = TestUtils.importNetwork(networkFileName);
+        XnecProvider xnecProvider = XnecProviderByIds.builder()
+                .addNetworkElementsOnBasecase(Set.of(branchId))
+                .build();
+        var flowDecompositionParameters = FlowDecompositionParameters.load().setEnableLossesCompensation(true);
+        FlowDecompositionComputer flowComputer = new FlowDecompositionComputer(flowDecompositionParameters);
+        var report = new ObserverReport();
+        flowComputer.addObserver(report);
+        flowComputer.run(xnecProvider, network);
+
+        // there are no losses in acNodalInjection
+        report.acNodalInjections.forBaseCase().forEach((inj, p) -> assertFalse(inj.startsWith(LossesCompensator.LOSSES_ID_PREFIX)));
+    }
+
     private void assertEventsFired(Collection<Event> firedEvents, Event... expectedEvents) {
         var missing = new HashSet<Event>();
         Collections.addAll(missing, expectedEvents);
         missing.removeAll(firedEvents);
-        assertTrue(missing.isEmpty(), () -> "Missing events: " + missing.toString());
+        assertTrue(missing.isEmpty(), () -> "Missing events: " + missing);
     }
 
     private static final class ContingencyValue<T> {
-        private Map<String, T> values = new HashMap<>();
+        private final Map<String, T> values = new HashMap<>();
 
         public void put(String contingencyId, T value) {
             values.put(contingencyId, value);

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.flow_decomposition;
+
+import com.powsybl.flow_decomposition.xnec_provider.XnecProviderAllBranches;
+import com.powsybl.flow_decomposition.xnec_provider.XnecProviderByIds;
+import com.powsybl.flow_decomposition.xnec_provider.XnecProviderUnion;
+import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Identifiable;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.loadflow.LoadFlowParameters;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.powsybl.flow_decomposition.TestUtils.validateFlowDecomposition;
+import static java.lang.Double.NaN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
+ */
+public class FlowDecompositionTests {
+
+    public static final double EPSILON = 1e-6;
+
+    @Test
+    void testFlowDecompositionOnNetworkWithBusBarSectionOnly() {
+        Network network = TestUtils.getMicroGridNetworkWithBusBarSectionOnly();
+
+        FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, new XnecProviderAllBranches());
+        assertEquals(6, flowDecompositionResults.getDecomposedFlowMap().size());
+        validateFlowDecomposition(flowDecompositionResults, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", "", Country.BE, Country.BE, 105.367771, 115.127961, -8.071105, 30.705093, 33.029749, 59.464224, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "b58bf21a-096a-4dae-9a01-3f03b60c24c7", "b58bf21a-096a-4dae-9a01-3f03b60c24c7", "", Country.BE, Country.BE, -116.377022, -118.547677, -0.000000, 126.160372, -0.000000, -7.612696, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "b94318f6-6d24-4f56-96b9-df2531ad6543", "b94318f6-6d24-4f56-96b9-df2531ad6543", "", Country.BE, Country.BE, 0.330698, 0.287049, -4.994947, 76.274497, -33.029749, -37.962752, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "df16b3dd-c905-4a6f-84ee-f067be86f5da", "df16b3dd-c905-4a6f-84ee-f067be86f5da", "", Country.BE, Country.BE, -99.872370, -103.741300, 0.000000, 103.741300, -0.000000, -0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "e482b89a-fa84-4ea9-8e70-a83d44790957", "e482b89a-fa84-4ea9-8e70-a83d44790957", "", Country.BE, Country.BE, -94.838378, -84.584990, 13.066052, -106.979590, -0.000000, 178.498528, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "ffbabc27-1ccd-4fdc-b037-e341706c8d29", "ffbabc27-1ccd-4fdc-b037-e341706c8d29", "", Country.BE, Country.BE, -53.579738, -57.103247, -0.000000, 60.770208, -0.000000, -3.666960, 0.000000, 0.000000, 0.000000, 0.000000);
+        assertEquals(1, flowDecompositionResults.getZoneSet().size());
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.BE));
+
+    }
+
+    @Test
+    void testFlowDecompositionOnNetworkWithShuntCompensatorOnly() {
+        Network network = TestUtils.getMicroGridNetworkWithShuntCompensatorOnly();
+
+        FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, new XnecProviderAllBranches());
+        assertEquals(6, flowDecompositionResults.getDecomposedFlowMap().size());
+        validateFlowDecomposition(flowDecompositionResults, "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", "a708c3bc-465d-4fe7-b6ef-6fa6408a62b0", "", Country.BE, Country.BE, 105.223381, 115.160484, -8.066648, 30.705093, 33.029749, 59.492290, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "b58bf21a-096a-4dae-9a01-3f03b60c24c7", "b58bf21a-096a-4dae-9a01-3f03b60c24c7", "", Country.BE, Country.BE, -116.362525, -118.534989, -0.000000, 126.160372, -0.000000, -7.625383, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "b94318f6-6d24-4f56-96b9-df2531ad6543", "b94318f6-6d24-4f56-96b9-df2531ad6543", "", Country.BE, Country.BE, -0.700299, 0.246463, -4.992189, 76.274497, -33.029749, -38.006096, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "df16b3dd-c905-4a6f-84ee-f067be86f5da", "df16b3dd-c905-4a6f-84ee-f067be86f5da", "", Country.BE, Country.BE, -99.868184, -103.741300, 0.000000, 103.741300, -0.000000, -0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "e482b89a-fa84-4ea9-8e70-a83d44790957", "e482b89a-fa84-4ea9-8e70-a83d44790957", "", Country.BE, Country.BE, -95.848612, -84.605325, 13.058837, -106.979590, -0.000000, 178.526079, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "ffbabc27-1ccd-4fdc-b037-e341706c8d29", "ffbabc27-1ccd-4fdc-b037-e341706c8d29", "", Country.BE, Country.BE, -53.568417, -57.097136, -0.000000, 60.770208, -0.000000, -3.673072, 0.000000, 0.000000, 0.000000, 0.000000);
+        assertEquals(1, flowDecompositionResults.getZoneSet().size());
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.BE));
+
+    }
+
+    @Test
+    void testFlowDecompositionOnNetworkWithStaticVarCompensatorOnly() {
+        Network network = TestUtils.getNetworkWithStaticVarCompensatorOnly();
+
+        FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, new XnecProviderAllBranches());
+        assertEquals(1, flowDecompositionResults.getDecomposedFlowMap().size());
+        validateFlowDecomposition(flowDecompositionResults, "L1", "L1", "", Country.FR, Country.FR, 100.260455, 100.000000, -0.000000, 0.000000, 0.000000, 100.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        assertEquals(1, flowDecompositionResults.getZoneSet().size());
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.FR));
+    }
+
+    @Test
+    void testFlowDecompositionOnHvdcNetwork() {
+        Network network = TestUtils.importNetwork("TestCase16NodesWithHvdc.xiidm");
+
+        Set<String> branchIds = network.getBranchStream().map(Identifiable::getId).collect(Collectors.toSet());
+        XnecProvider xnecProviderContingency = XnecProviderByIds.builder()
+            .addContingency("contingency_1", Set.of("DDE2AA11 NNL3AA11 1"))
+            .addContingency("contingency_desync", Set.of("DDE2AA11 NNL3AA11 1", "FFR3AA11 FFR5AA11 1"))
+            .addContingency("contingency_split_network", Set.of("DDE2AA11 NNL3AA11 1", "FFR3AA11 FFR5AA11 1", "NNL2AA11 BBE3AA11 1"))
+            .addNetworkElementsAfterContingencies(branchIds, Set.of("contingency_1", "contingency_desync", "contingency_split_network"))
+            .build();
+        XnecProvider xnecProvider = new XnecProviderUnion(List.of(new XnecProviderAllBranches(), xnecProviderContingency));
+        FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, xnecProvider);
+        assertEquals(98, flowDecompositionResults.getDecomposedFlowMap().size());
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 1_contingency_split_network", "BBE1AA11 BBE3AA11 1", "contingency_split_network", Country.BE, Country.BE, -571.575251, -571.428571, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 2", "FFR2AA11 FFR3AA11 2", "", Country.FR, Country.FR, -1048.852694, -1044.697128, 418.391705, 0.000000, 38.815350, 611.949424, -16.125814, -4.610042, 0.000000, -3.723495);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 1", "FFR2AA11 FFR3AA11 1", "", Country.FR, Country.FR, -1048.852694, -1044.697128, 418.391705, 0.000000, 38.815350, 611.949424, -16.125814, -4.610042, 0.000000, -3.723495);
+        validateFlowDecomposition(flowDecompositionResults, "FFR3AA11 FFR5AA11 1", "FFR3AA11 FFR5AA11 1", "", Country.FR, Country.FR, -1012.008034, -1009.730695, 1246.058874, 0.000000, 18.657301, -134.559417, -46.431224, -63.273741, 0.000000, -10.721099);
+        validateFlowDecomposition(flowDecompositionResults, "DDE2AA11 DDE3AA11 1_contingency_1", "DDE2AA11 DDE3AA11 1", "contingency_1", Country.DE, Country.DE, -553.509702, -561.186194, 443.113772, 0.000000, -70.550332, 125.748503, 0.000000, 0.000000, 62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE4AA11 1_contingency_1", "FFR4AA11 DDE4AA11 1", "contingency_1", Country.FR, Country.DE, 148.880291, 146.271269, 518.962076, 0.000000, 23.516777, 0.000000, 0.000000, -375.249501, -20.958084, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR4AA11 1_contingency_split_network", "FFR1AA11 FFR4AA11 1", "contingency_split_network", Country.FR, Country.FR, 871.892782, 889.220358, 431.137725, 0.000000, -161.677845, 706.586826, 0.000000, -86.826347, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 2_contingency_split_network", "FFR2AA11 FFR3AA11 2", "contingency_split_network", Country.FR, Country.FR, -625.590192, -622.155928, -86.227545, 0.000000, 32.335569, 658.682635, 0.000000, 17.365269, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE4AA11 1_contingency_1", "DDE1AA11 DDE4AA11 1", "contingency_1", Country.DE, Country.DE, -648.880291, -646.271269, 118.962076, 0.000000, 23.516777, 524.750499, 0.000000, 0.000000, -20.958084, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL2AA11 1_contingency_1", "NNL1AA11 NNL2AA11 1", "contingency_1", Country.NL, Country.NL, 166.672696, 166.666667, -208.333333, 0.000000, -0.000000, 375.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 BBE3AA11 1_contingency_1", "NNL2AA11 BBE3AA11 1", "contingency_1", Country.NL, Country.BE, -500.000000, -500.000000, 500.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL2AA11 1_contingency_desync", "NNL1AA11 NNL2AA11 1", "contingency_desync", Country.NL, Country.NL, 166.672696, 166.666667, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR4AA11 1", "FFR1AA11 FFR4AA11 1", "", Country.FR, Country.FR, 779.213147, 795.975751, 400.159224, 0.000000, -156.762149, 671.134046, -12.233376, -103.497273, 0.000000, -2.824721);
+        validateFlowDecomposition(flowDecompositionResults, "FFR3AA11 FFR5AA11 1_contingency_1", "FFR3AA11 FFR5AA11 1", "contingency_1", Country.FR, Country.FR, -2000.000000, -2000.000000, 2000.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL2AA11 1", "NNL1AA11 NNL2AA11 1", "", Country.NL, Country.NL, -162.721962, -163.423102, 459.647042, 0.000000, -6.219100, -371.426300, 15.477075, 21.091247, 44.853139, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR5AA11 1_contingency_desync", "FFR1AA11 FFR5AA11 1", "contingency_desync", Country.FR, Country.FR, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE4AA11 1_contingency_split_network", "DDE1AA11 DDE4AA11 1", "contingency_split_network", Country.DE, Country.DE, -636.877548, -634.295221, 106.986028, 0.000000, 23.516777, 524.750499, 0.000000, 0.000000, -20.958084, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE1AA11 1", "FFR4AA11 DDE1AA11 1", "", Country.FR, Country.DE, 478.144120, 472.335696, 394.134806, 0.000000, 53.066455, 0.000000, -15.013689, 129.041225, -85.426398, -3.466703);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 BBE3AA11 1", "NNL2AA11 BBE3AA11 1", "", Country.NL, Country.BE, -1487.991966, -1490.269305, 1253.941126, 0.000000, -18.657301, 0.000000, 46.431224, 63.273741, 134.559417, 10.721099);
+        validateFlowDecomposition(flowDecompositionResults, "BBE2AA11 BBE3AA11 1", "BBE2AA11 BBE3AA11 1", "", Country.BE, Country.BE, 926.977948, 927.181329, 423.495349, 0.000000, -2.665329, 476.557844, 0.000000, 9.039106, 19.222774, 1.531586);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE2AA11 1_contingency_desync", "DDE1AA11 DDE2AA11 1", "contingency_desync", Country.DE, Country.DE, 410.522825, 402.885662, 54.291417, 0.000000, 70.550332, 340.918164, 0.000000, 0.000000, -62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL3AA11 1_contingency_1", "NNL1AA11 NNL3AA11 1", "contingency_1", Country.NL, Country.NL, 333.327304, 333.333333, 20.833333, 0.000000, -0.000000, 312.500000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE4AA11 1", "FFR4AA11 DDE4AA11 1", "", Country.FR, Country.DE, -10.930437, -13.832152, -397.067403, 0.000000, -26.533227, 0.000000, 7.506845, 385.479387, 42.713199, 1.733351);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR5AA11 1_contingency_split_network", "FFR1AA11 FFR5AA11 1", "contingency_split_network", Country.FR, Country.FR, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 NNL3AA11 1_contingency_desync", "NNL2AA11 NNL3AA11 1", "contingency_desync", Country.NL, Country.NL, 166.672696, 166.666667, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE2AA11 1", "BBE1AA11 BBE2AA11 1", "", Country.BE, Country.BE, -1073.022052, -1072.818671, 365.978335, 0.000000, 2.665329, 733.968472, 0.000000, -9.039106, -19.222774, -1.531586);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE4AA11 1_contingency_split_network", "FFR4AA11 DDE4AA11 1", "contingency_split_network", Country.FR, Country.DE, 136.883741, 134.295221, 506.986028, 0.000000, 23.516777, 0.000000, 0.000000, -375.249501, -20.958084, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 BBE3AA11 1_contingency_desync", "NNL2AA11 BBE3AA11 1", "contingency_desync", Country.NL, Country.BE, -500.000000, -500.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 DDE3AA11 1", "FFR2AA11 DDE3AA11 1", "", Country.FR, Country.DE, 544.794351, 551.227151, 454.856666, 0.000000, -60.942381, 0.000000, -23.910690, 193.164421, -6.419820, -5.521045);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE2AA11 1_contingency_split_network", "BBE1AA11 BBE2AA11 1", "contingency_split_network", Country.BE, Country.BE, -1285.274247, -1285.714286, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE2AA11 1_contingency_1", "DDE1AA11 DDE2AA11 1", "contingency_1", Country.DE, Country.DE, 446.490298, 438.813806, 90.219561, 0.000000, 70.550332, 340.918164, 0.000000, 0.000000, -62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR4AA11 1_contingency_split_network", "FFR2AA11 FFR4AA11 1", "contingency_split_network", Country.FR, Country.FR, 1038.609398, 1013.665303, 689.820359, 0.000000, 232.228178, 230.538922, 0.000000, -138.922156, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 DDE3AA11 1_contingency_desync", "FFR2AA11 DDE3AA11 1", "contingency_desync", Country.FR, Country.DE, 1089.444201, 1097.114338, 879.041916, 0.000000, -70.550332, 0.000000, 0.000000, 225.748503, 62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR3AA11 1", "FFR1AA11 FFR3AA11 1", "", Country.FR, Country.FR, -414.302646, -420.336439, 409.275465, 0.000000, -58.973399, 141.541735, -14.179595, -54.053657, 0.000000, -3.274108);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 DDE3AA11 1_contingency_1", "FFR2AA11 DDE3AA11 1", "contingency_1", Country.FR, Country.DE, 1053.509702, 1061.186194, 843.113772, 0.000000, -70.550332, 0.000000, 0.000000, 225.748503, 62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE4AA11 1", "DDE1AA11 DDE4AA11 1", "", Country.DE, Country.DE, -489.069563, -486.167848, -2.932597, 0.000000, 26.533227, 514.520613, -7.506845, 0.000000, -42.713199, -1.733351);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL3AA11 1_contingency_desync", "NNL1AA11 NNL3AA11 1", "contingency_desync", Country.NL, Country.NL, 333.327304, 333.333333, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE2AA11 DDE3AA11 1_contingency_desync", "DDE2AA11 DDE3AA11 1", "contingency_desync", Country.DE, Country.DE, -589.470478, -597.114338, 479.041916, 0.000000, -70.550332, 125.748503, 0.000000, 0.000000, 62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE2AA11 BBE3AA11 1_contingency_split_network", "BBE2AA11 BBE3AA11 1", "contingency_split_network", Country.BE, Country.BE, 714.725753, 714.285714, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL3AA11 1_contingency_split_network", "NNL1AA11 NNL3AA11 1", "contingency_split_network", Country.NL, Country.NL, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 2_contingency_desync", "BBE1AA11 BBE3AA11 2", "contingency_desync", Country.BE, Country.BE, -428.685692, -428.571429, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE2AA11 1_contingency_desync", "BBE1AA11 BBE2AA11 1", "contingency_desync", Country.BE, Country.BE, -1213.942924, -1214.285714, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 2_contingency_desync", "FFR2AA11 FFR3AA11 2", "contingency_desync", Country.FR, Country.FR, -625.590192, -622.155928, -86.227545, 0.000000, 32.335569, 658.682635, 0.000000, 17.365269, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 FFR5AA11 1_contingency_desync", "BBE1AA11 FFR5AA11 1", "contingency_desync", Country.BE, Country.FR, 0.000000, -0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE3AA11 BBE4AA11 1_contingency_1", "BBE3AA11 BBE4AA11 1", "contingency_1", Country.BE, Country.BE, 428.685692, 428.571429, 157.894737, 0.000000, 0.000000, 270.676692, 0.000000, 0.000000, 0.000000, -0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 1_contingency_desync", "BBE1AA11 BBE3AA11 1", "contingency_desync", Country.BE, Country.BE, -428.685692, -428.571429, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR4AA11 1_contingency_desync", "FFR2AA11 FFR4AA11 1", "contingency_desync", Country.FR, Country.FR, 1038.609398, 1013.665303, 689.820359, 0.000000, 232.228178, 230.538922, 0.000000, -138.922156, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE2AA11 1_contingency_split_network", "DDE1AA11 DDE2AA11 1", "contingency_split_network", Country.DE, Country.DE, 410.522825, 402.885662, 54.291417, 0.000000, 70.550332, 340.918164, 0.000000, 0.000000, -62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 1_contingency_desync", "FFR2AA11 FFR3AA11 1", "contingency_desync", Country.FR, Country.FR, -625.590192, -622.155928, -86.227545, 0.000000, 32.335569, 658.682635, 0.000000, 17.365269, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 1_contingency_split_network", "FFR2AA11 FFR3AA11 1", "contingency_split_network", Country.FR, Country.FR, -625.590192, -622.155928, -86.227545, 0.000000, 32.335569, 658.682635, 0.000000, 17.365269, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE3AA11 BBE4AA11 1", "BBE3AA11 BBE4AA11 1", "", Country.BE, Country.BE, 146.328661, 145.637341, -57.517013, 0.000000, 5.330657, 257.410628, 0.000000, -18.078212, -38.445548, -3.063171);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR2AA11 1_contingency_1", "FFR1AA11 FFR2AA11 1", "contingency_1", Country.FR, Country.FR, 676.752713, 665.868983, 40.718563, 0.000000, 97.006707, 476.047904, 0.000000, 52.095808, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE2AA11 BBE3AA11 1_contingency_1", "BBE2AA11 BBE3AA11 1", "contingency_1", Country.BE, Country.BE, 786.057076, 785.714286, 315.789474, 0.000000, 0.000000, 469.924812, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR3AA11 1_contingency_desync", "FFR1AA11 FFR3AA11 1", "contingency_desync", Country.FR, Country.FR, -248.807353, -255.688143, 172.455090, 0.000000, -64.671138, 182.634731, 0.000000, -34.730539, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 2_contingency_split_network", "BBE1AA11 BBE3AA11 2", "contingency_split_network", Country.BE, Country.BE, -571.575251, -571.428571, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE2AA11 DDE3AA11 1_contingency_split_network", "DDE2AA11 DDE3AA11 1", "contingency_split_network", Country.DE, Country.DE, -589.470478, -597.114338, 479.041916, 0.000000, -70.550332, 125.748503, 0.000000, 0.000000, 62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 DDE3AA11 1_contingency_split_network", "FFR2AA11 DDE3AA11 1", "contingency_split_network", Country.FR, Country.DE, 1089.444201, 1097.114338, 879.041916, 0.000000, -70.550332, 0.000000, 0.000000, 225.748503, 62.874251, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 2", "BBE1AA11 BBE3AA11 2", "", Country.BE, Country.BE, -146.328661, -145.637341, -57.517013, 0.000000, 5.330657, 257.410628, 0.000000, -18.078212, -38.445548, -3.063171);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 FFR5AA11 1", "BBE1AA11 FFR5AA11 1", "", Country.BE, Country.FR, 506.004017, 504.865347, 623.029437, 0.000000, 9.328651, 0.000000, -23.215612, -31.636871, -67.279708, -5.360549);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 1", "BBE1AA11 BBE3AA11 1", "", Country.BE, Country.BE, -146.328661, -145.637341, -57.517013, 0.000000, 5.330657, 257.410628, 0.000000, -18.078212, -38.445548, -3.063171);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 NNL3AA11 1_contingency_split_network", "NNL2AA11 NNL3AA11 1", "contingency_split_network", Country.NL, Country.NL, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE4AA11 FFR5AA11 1_contingency_split_network", "BBE4AA11 FFR5AA11 1", "contingency_split_network", Country.BE, Country.FR, 0.000000, -0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE2AA11 BBE3AA11 1_contingency_desync", "BBE2AA11 BBE3AA11 1", "contingency_desync", Country.BE, Country.BE, 786.057076, 785.714286, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 1_contingency_1", "BBE1AA11 BBE3AA11 1", "contingency_1", Country.BE, Country.BE, -428.685692, -428.571429, 157.894737, 0.000000, 0.000000, 270.676692, 0.000000, 0.000000, 0.000000, -0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 FFR5AA11 1_contingency_split_network", "BBE1AA11 FFR5AA11 1", "contingency_split_network", Country.BE, Country.FR, 0.000000, -0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE1AA11 1_contingency_desync", "FFR4AA11 DDE1AA11 1", "contingency_desync", Country.FR, Country.DE, 773.629497, 768.590441, 613.972056, 0.000000, 47.033555, 0.000000, 0.000000, 149.500998, -41.916168, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE2AA11 1_contingency_1", "BBE1AA11 BBE2AA11 1", "contingency_1", Country.BE, Country.BE, -1213.942924, -1214.285714, 473.684211, 0.000000, 0.000000, 740.601504, 0.000000, 0.000000, 0.000000, -0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR3AA11 1_contingency_1", "FFR1AA11 FFR3AA11 1", "contingency_1", Country.FR, Country.FR, -716.378043, -722.754012, 639.520958, 0.000000, -64.671138, 182.634731, 0.000000, -34.730539, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE2AA11 1", "DDE1AA11 DDE2AA11 1", "", Country.DE, Country.DE, -32.786317, -41.496456, 275.464458, 0.000000, -79.599682, -310.228505, 22.520534, 0.000000, 128.139597, 5.200054);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR2AA11 1", "FFR1AA11 FFR2AA11 1", "", Country.FR, Country.FR, 635.089500, 624.360688, 9.116240, 0.000000, 97.788750, 470.407689, -1.946219, 49.443616, 0.000000, -0.449387);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE1AA11 1_contingency_split_network", "FFR4AA11 DDE1AA11 1", "contingency_split_network", Country.FR, Country.DE, 773.629497, 768.590441, 613.972056, 0.000000, 47.033555, 0.000000, 0.000000, 149.500998, -41.916168, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 NNL3AA11 1", "NNL2AA11 NNL3AA11 1", "", Country.NL, Country.NL, 825.270004, 826.846203, 731.794084, 0.000000, -12.438201, -55.352601, 30.954149, 42.182494, 89.706278, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE4AA11 FFR5AA11 1_contingency_desync", "BBE4AA11 FFR5AA11 1", "contingency_desync", Country.BE, Country.FR, 0.000000, -0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE1AA11 DDE4AA11 1_contingency_desync", "DDE1AA11 DDE4AA11 1", "contingency_desync", Country.DE, Country.DE, -636.877548, -634.295221, 106.986028, 0.000000, 23.516777, 524.750499, 0.000000, 0.000000, -20.958084, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL2AA11 1_contingency_split_network", "NNL1AA11 NNL2AA11 1", "contingency_split_network", Country.NL, Country.NL, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE4AA11 1_contingency_desync", "FFR4AA11 DDE4AA11 1", "contingency_desync", Country.FR, Country.DE, 136.883741, 134.295221, 506.986028, 0.000000, 23.516777, 0.000000, 0.000000, -375.249501, -20.958084, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR5AA11 1", "FFR1AA11 FFR5AA11 1", "", Country.FR, Country.FR, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE3AA11 BBE4AA11 1_contingency_desync", "BBE3AA11 BBE4AA11 1", "contingency_desync", Country.BE, Country.BE, 428.685692, 428.571429, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 FFR5AA11 1_contingency_1", "BBE1AA11 FFR5AA11 1", "contingency_1", Country.BE, Country.FR, 1000.000000, 1000.000000, 1000.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL1AA11 NNL3AA11 1", "NNL1AA11 NNL3AA11 1", "", Country.NL, Country.NL, 662.721962, 663.423102, 272.147042, 0.000000, -6.219100, 316.073700, 15.477075, 21.091247, 44.853139, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR4AA11 DDE1AA11 1_contingency_1", "FFR4AA11 DDE1AA11 1", "contingency_1", Country.FR, Country.DE, 797.610007, 792.542537, 637.924152, 0.000000, 47.033555, 0.000000, 0.000000, 149.500998, -41.916168, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR2AA11 1_contingency_desync", "FFR1AA11 FFR2AA11 1", "contingency_desync", Country.FR, Country.FR, 376.897452, 366.467785, -258.682635, 0.000000, 97.006707, 476.047904, 0.000000, 52.095808, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR4AA11 1_contingency_desync", "FFR1AA11 FFR4AA11 1", "contingency_desync", Country.FR, Country.FR, 871.892782, 889.220358, 431.137725, 0.000000, -161.677845, 706.586826, 0.000000, -86.826347, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR4AA11 1_contingency_1", "FFR2AA11 FFR4AA11 1", "contingency_1", Country.FR, Country.FR, 906.864968, 881.928776, 558.083832, 0.000000, 232.228178, 230.538922, 0.000000, -138.922156, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 2_contingency_1", "FFR2AA11 FFR3AA11 2", "contingency_1", Country.FR, Country.FR, -1391.810978, -1388.622994, 680.239521, 0.000000, 32.335569, 658.682635, 0.000000, 17.365269, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "NNL2AA11 NNL3AA11 1_contingency_1", "NNL2AA11 NNL3AA11 1", "contingency_1", Country.NL, Country.NL, 166.672696, 166.666667, 229.166667, 0.000000, -0.000000, -62.500000, -0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR2AA11 1_contingency_split_network", "FFR1AA11 FFR2AA11 1", "contingency_split_network", Country.FR, Country.FR, 376.897452, 366.467785, -258.682635, 0.000000, 97.006707, 476.047904, 0.000000, 52.095808, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR3AA11 1_contingency_1", "FFR2AA11 FFR3AA11 1", "contingency_1", Country.FR, Country.FR, -1391.810978, -1388.622994, 680.239521, 0.000000, 32.335569, 658.682635, 0.000000, 17.365269, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR4AA11 1_contingency_1", "FFR1AA11 FFR4AA11 1", "contingency_1", Country.FR, Country.FR, 1039.625330, 1056.885029, 598.802395, 0.000000, -161.677845, 706.586826, 0.000000, -86.826347, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE4AA11 FFR5AA11 1_contingency_1", "BBE4AA11 FFR5AA11 1", "contingency_1", Country.BE, Country.FR, 1000.000000, 1000.000000, 1000.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE2AA11 DDE3AA11 1", "DDE2AA11 DDE3AA11 1", "", Country.DE, Country.DE, -44.794351, -51.227151, 54.856666, 0.000000, -60.942381, 93.164421, -23.910690, 0.000000, -6.419820, -5.521045);
+        validateFlowDecomposition(flowDecompositionResults, "BBE3AA11 BBE4AA11 1_contingency_split_network", "BBE3AA11 BBE4AA11 1", "contingency_split_network", Country.BE, Country.BE, 571.575251, 571.428571, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "DDE2AA11 NNL3AA11 1", "DDE2AA11 NNL3AA11 1", "", Country.DE, Country.NL, -987.991966, -990.269305, 753.941126, 0.000000, -18.657301, 0.000000, 46.431224, 63.273741, 134.559417, 10.721099);
+        validateFlowDecomposition(flowDecompositionResults, "FFR2AA11 FFR4AA11 1", "FFR2AA11 FFR4AA11 1", "", Country.FR, Country.FR, 688.000536, 662.527793, 391.042984, 0.000000, 236.361831, 200.726357, -10.287157, -152.940889, 0.000000, -2.375333);
+        validateFlowDecomposition(flowDecompositionResults, "BBE4AA11 FFR5AA11 1", "BBE4AA11 FFR5AA11 1", "", Country.BE, Country.FR, 506.004017, 504.865347, 623.029437, 0.000000, 9.328651, 0.000000, -23.215612, -31.636871, -67.279708, -5.360549);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR3AA11 1_contingency_split_network", "FFR1AA11 FFR3AA11 1", "contingency_split_network", Country.FR, Country.FR, -248.807353, -255.688143, 172.455090, 0.000000, -64.671138, 182.634731, 0.000000, -34.730539, 0.000000, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "BBE1AA11 BBE3AA11 2_contingency_1", "BBE1AA11 BBE3AA11 2", "contingency_1", Country.BE, Country.BE, -428.685692, -428.571429, 157.894737, 0.000000, 0.000000, 270.676692, 0.000000, 0.000000, 0.000000, -0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FFR1AA11 FFR5AA11 1_contingency_1", "FFR1AA11 FFR5AA11 1", "contingency_1", Country.FR, Country.FR, NaN, NaN, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000, 0.000000);
+        assertEquals(4, flowDecompositionResults.getZoneSet().size());
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.BE));
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.DE));
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.FR));
+        assertTrue(flowDecompositionResults.getZoneSet().contains(Country.NL));
+    }
+
+    private static FlowDecompositionResults runFlowDecomposition(Network network, XnecProvider xnecProvider) {
+        FlowDecompositionParameters flowDecompositionParameters = new FlowDecompositionParameters()
+            .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)
+            .setLossesCompensationEpsilon(FlowDecompositionParameters.DISABLE_LOSSES_COMPENSATION_EPSILON)
+            .setSensitivityEpsilon(FlowDecompositionParameters.DISABLE_SENSITIVITY_EPSILON)
+            .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE);
+        FlowDecompositionComputer flowDecompositionComputer = new FlowDecompositionComputer(flowDecompositionParameters, new LoadFlowParameters());
+        FlowDecompositionResults flowDecompositionResults = flowDecompositionComputer.run(xnecProvider, network);
+        TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.getRescaleMode(), flowDecompositionResults);
+        return flowDecompositionResults;
+    }
+}

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NetPositionTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NetPositionTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * @author Sebastien Murgey {@literal <sebastien.murgey at rte-france.com>}
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
- * @author Hugo Schindler{@literal <hugo.schindler@rte-france.com>}
+ * @author Hugo Schindler{@literal <hugo.schindler at rte-france.com>}
  */
 class NetPositionTest {
     private static final double DOUBLE_TOLERANCE = 1e-3;

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NetworkUtilTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NetworkUtilTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2024, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+package com.powsybl.flow_decomposition;
+
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.FourSubstationsNodeBreakerFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
+ */
+class NetworkUtilTest {
+
+    @Test
+    void testGetFlowIdFromCountry() {
+        Network network = TestUtils.importNetwork("19700101_0000_FO4_UX1.uct");
+
+        assertEquals("Loop Flow from SI", NetworkUtil.getLoopFlowIdFromCountry(Country.SI));
+
+        assertEquals("Loop Flow from BE", NetworkUtil.getLoopFlowIdFromCountry(network, "BB000021_load"));
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> NetworkUtil.getLoopFlowIdFromCountry(network, "DUMMY"));
+
+        assertEquals("Identifiable DUMMY must be an Injection", exception.getMessage());
+    }
+
+    @Test
+    void testGetFlowIdFromCountryWithNetworkWithoutCountries() {
+        Network network = FourSubstationsNodeBreakerFactory.create();
+        PowsyblException exception = assertThrows(PowsyblException.class, () -> NetworkUtil.getLoopFlowIdFromCountry(network, "GH1"));
+        assertEquals("Substation S1 does not have country property needed for the algorithm.", exception.getMessage());
+    }
+
+    @Test
+    void testGetIndex() {
+        Map<String, Integer> result = Map.of("a", 0, "b", 1, "c", 2);
+        assertEquals(result, NetworkUtil.getIndex(List.of("a", "b", "c")));
+    }
+
+    @Test
+    void testGetAllValidBranches() {
+        Network network = TestUtils.importNetwork("NETWORK_LOOP_FLOW_WITH_COUNTRIES.uct");
+
+        List<Branch> allValidBranches = NetworkUtil.getAllValidBranches(network);
+        assertEquals(5, allValidBranches.size());
+        assertTrue(allValidBranches.contains(network.getBranch("EGEN  11 FGEN  11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("FGEN  11 BGEN  11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("BGEN  11 BLOAD 11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("BLOAD 11 FLOAD 11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("FLOAD 11 ELOAD 11 1")));
+    }
+
+    @Test
+    void testGetAllValidBranchesWithDisconnectedTerminals() {
+        Network network = TestUtils.importNetwork("NETWORK_LOOP_FLOW_WITH_COUNTRIES.uct");
+        network.getBranch("BLOAD 11 FLOAD 11 1").getTerminal2().disconnect();
+        network.getBranch("FGEN  11 BGEN  11 1").getTerminal1().disconnect();
+
+        List<Branch> allValidBranches = NetworkUtil.getAllValidBranches(network);
+        assertEquals(1, allValidBranches.size());
+        assertTrue(allValidBranches.contains(network.getBranch("EGEN  11 FGEN  11 1")));
+        assertFalse(allValidBranches.contains(network.getBranch("FGEN  11 BGEN  11 1")));
+        assertFalse(allValidBranches.contains(network.getBranch("BGEN  11 BLOAD 11 1")));
+        assertFalse(allValidBranches.contains(network.getBranch("BLOAD 11 FLOAD 11 1")));
+        assertFalse(allValidBranches.contains(network.getBranch("FLOAD 11 ELOAD 11 1")));
+    }
+
+    @Test
+    void testGetAllValidBranchesWithLinesOutsideMainConnectedComponent() {
+        Network network = TestUtils.importNetwork("NETWORK_LOOP_FLOW_WITH_COUNTRIES.uct");
+        network.getLine("FGEN  11 BGEN  11 1").disconnect();
+        assertFalse(network.getBranch("EGEN  11 FGEN  11 1").getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertFalse(network.getBranch("EGEN  11 FGEN  11 1").getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+
+        List<Branch> allValidBranches = NetworkUtil.getAllValidBranches(network);
+        assertEquals(3, allValidBranches.size());
+        assertFalse(allValidBranches.contains(network.getBranch("EGEN  11 FGEN  11 1")));
+        assertFalse(allValidBranches.contains(network.getBranch("FGEN  11 BGEN  11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("BGEN  11 BLOAD 11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("BLOAD 11 FLOAD 11 1")));
+        assertTrue(allValidBranches.contains(network.getBranch("FLOAD 11 ELOAD 11 1")));
+    }
+
+    @Test
+    void testGetAllValidBranchesWithLinesOutsideMainSynchronousComponent() {
+        Network network = TestUtils.importNetwork("TestCase16NodesWithHvdc.xiidm");
+        assertEquals(1, network.getBusView().getConnectedComponents().size());
+        assertEquals(1, network.getBusView().getSynchronousComponents().size());
+        Line lineOutsideSync = network.getLine("BBE1AA11 FFR5AA11 1");
+        assertTrue(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertTrue(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+
+        Line lineDisconnected1 = network.getLine("DDE2AA11 NNL3AA11 1");
+        Line lineDisconnected2 = network.getLine("FFR3AA11 FFR5AA11 1");
+        lineDisconnected1.disconnect();
+        lineDisconnected2.disconnect();
+        assertEquals(1, network.getBusView().getConnectedComponents().size());
+        assertEquals(2, network.getBusView().getSynchronousComponents().size());
+        assertTrue(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertFalse(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+
+        validateValidBranches(network);
+    }
+
+    @Test
+    void testGetAllValidBranchesWithLinesOutsideMainConnectedAndSynchronousComponent() {
+        Network network = TestUtils.importNetwork("TestCase16NodesWithHvdc.xiidm");
+        assertEquals(1, network.getBusView().getConnectedComponents().size());
+        assertEquals(1, network.getBusView().getSynchronousComponents().size());
+        Line lineOutsideSync = network.getLine("BBE1AA11 FFR5AA11 1");
+        assertTrue(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertTrue(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+        Line lineOutsideConnected = network.getLine("NNL1AA11 NNL3AA11 1");
+        assertTrue(lineOutsideConnected.getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertTrue(lineOutsideConnected.getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+
+        Line lineDisconnected1 = network.getLine("DDE2AA11 NNL3AA11 1");
+        Line lineDisconnected2 = network.getLine("FFR3AA11 FFR5AA11 1");
+        Line lineDisconnected3 = network.getLine("NNL2AA11 BBE3AA11 1");
+        lineDisconnected1.disconnect();
+        lineDisconnected2.disconnect();
+        lineDisconnected3.disconnect();
+        assertEquals(2, network.getBusView().getConnectedComponents().size());
+        assertEquals(3, network.getBusView().getSynchronousComponents().size());
+        assertTrue(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertFalse(lineOutsideSync.getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+        assertFalse(lineOutsideConnected.getTerminal1().getBusBreakerView().getBus().isInMainConnectedComponent());
+        assertFalse(lineOutsideConnected.getTerminal1().getBusBreakerView().getBus().isInMainSynchronousComponent());
+
+        validateValidBranches(network);
+    }
+
+    private static void validateValidBranches(Network network) {
+        List<Branch> allValidBranches = NetworkUtil.getAllValidBranches(network);
+        assertEquals(12, allValidBranches.size());
+        assertTrue(allValidBranches.contains(network.getLine("DDE1AA11 DDE2AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("DDE1AA11 DDE4AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("DDE2AA11 DDE3AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR1AA11 FFR2AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR1AA11 FFR3AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR1AA11 FFR4AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR2AA11 DDE3AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR2AA11 FFR3AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR2AA11 FFR3AA11 2")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR4AA11 DDE1AA11 1")));
+        assertTrue(allValidBranches.contains(network.getLine("FFR4AA11 DDE4AA11 1")));
+        assertTrue(allValidBranches.contains(network.getTwoWindingsTransformer("FFR2AA11 FFR4AA11 1")));
+    }
+
+    @Test
+    void testGetNodeList() {
+        Network network = TestUtils.importNetwork("NETWORK_LOOP_FLOW_WITH_COUNTRIES.uct");
+
+        List<Injection<?>> nodeList = NetworkUtil.getNodeList(network);
+        assertEquals(6, nodeList.size());
+        assertTrue(nodeList.contains(network.getGenerator("EGEN  11_generator")));
+        assertTrue(nodeList.contains(network.getGenerator("FGEN  11_generator")));
+        assertTrue(nodeList.contains(network.getGenerator("BGEN  11_generator")));
+        assertTrue(nodeList.contains(network.getLoad("BLOAD 11_load")));
+        assertTrue(nodeList.contains(network.getLoad("FLOAD 11_load")));
+        assertTrue(nodeList.contains(network.getLoad("ELOAD 11_load")));
+    }
+
+    @Test
+    void testGetNodeListWithDisconnectedTerminals() {
+        Network network = TestUtils.importNetwork("NETWORK_LOOP_FLOW_WITH_COUNTRIES.uct");
+        network.getBranch("BLOAD 11 FLOAD 11 1").getTerminal2().disconnect();
+        network.getBranch("FGEN  11 BGEN  11 1").getTerminal1().disconnect();
+
+        List<Injection<?>> nodeList = NetworkUtil.getNodeList(network);
+        assertEquals(2, nodeList.size());
+        assertTrue(nodeList.contains(network.getGenerator("EGEN  11_generator")));
+        assertTrue(nodeList.contains(network.getGenerator("FGEN  11_generator")));
+    }
+
+    @Test
+    void testGetNodeListWithoutBusBarSection() {
+        Network network = TestUtils.getMicroGridNetworkWithBusBarSectionOnly();
+
+        List<Injection<?>> nodeList = NetworkUtil.getNodeList(network);
+        validateNodeListForMicroGridBE3DanglingLinesSameBoundary1Disconnected(nodeList, network);
+    }
+
+    @Test
+    void testGetNodeListWithoutShuntCompensator() {
+        Network network = TestUtils.getMicroGridNetworkWithShuntCompensatorOnly();
+
+        List<Injection<?>> nodeList = NetworkUtil.getNodeList(network);
+        validateNodeListForMicroGridBE3DanglingLinesSameBoundary1Disconnected(nodeList, network);
+    }
+
+    private static void validateNodeListForMicroGridBE3DanglingLinesSameBoundary1Disconnected(List<Injection<?>> nodeList, Network network) {
+        assertEquals(9, nodeList.size());
+        assertTrue(nodeList.contains(network.getGenerator("3a3b27be-b18b-4385-b557-6735d733baf0")));
+        assertTrue(nodeList.contains(network.getGenerator("550ebe0d-f2b2-48c1-991f-cebea43a21aa")));
+        assertTrue(nodeList.contains(network.getLoad("b1480a00-b427-4001-a26c-51954d2bb7e9")));
+        assertTrue(nodeList.contains(network.getLoad("1c6beed6-1acf-42e7-ba55-0cc9f04bddd8")));
+        assertTrue(nodeList.contains(network.getLoad("cb459405-cc14-4215-a45c-416789205904")));
+        assertTrue(nodeList.contains(network.getDanglingLine("ed0c5d75-4a54-43c8-b782-b20d7431630b")));
+        assertTrue(nodeList.contains(network.getDanglingLine("b18cd1aa-7808-49b9-a7cf-605eaf07b006")));
+        assertTrue(nodeList.contains(network.getDanglingLine("a16b4a6c-70b1-4abf-9a9d-bd0fa47f9fe4")));
+        assertTrue(nodeList.contains(network.getDanglingLine("17086487-56ba-4979-b8de-064025a6b4da")));
+    }
+
+    @Test
+    void testGetNodeListWithoutStaticVarCompensator() {
+        Network network = TestUtils.getNetworkWithStaticVarCompensatorOnly();
+
+        List<Injection<?>> nodeList = NetworkUtil.getNodeList(network);
+        assertEquals(2, nodeList.size());
+        assertTrue(nodeList.contains(network.getGenerator("G1")));
+        assertTrue(nodeList.contains(network.getLoad("L2")));
+    }
+
+    @Test
+    void testGetXNodeList() {
+        Network network = TestUtils.importNetwork("NETWORK_SINGLE_LOAD_TWO_GENERATORS_WITH_UNBOUNDED_XNODE.uct");
+
+        List<Injection<?>> nodeList = NetworkUtil.getXNodeList(network);
+        assertEquals(1, nodeList.size());
+        assertTrue(nodeList.contains(network.getDanglingLine("BLOAD 11 X     11 1")));
+    }
+
+    @Test
+    void testGetPstIdList() {
+        Network network = TestUtils.importNetwork("NETWORK_PST_FLOW_WITH_COUNTRIES.uct");
+        List<String> nodeList = NetworkUtil.getPstIdList(network);
+        assertEquals(1, nodeList.size());
+        assertTrue(nodeList.contains("BLOAD 11 BLOAD 12 2"));
+    }
+}

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/TestUtils.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/TestUtils.java
@@ -6,15 +6,18 @@
  */
 package com.powsybl.flow_decomposition;
 
+import com.powsybl.cgmes.conformity.CgmesConformity3ModifiedCatalog;
 import com.powsybl.glsk.api.GlskDocument;
 import com.powsybl.glsk.api.io.GlskDocumentImporters;
-import com.powsybl.iidm.network.Bus;
-import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.Terminal;
+import com.powsybl.iidm.network.*;
+import com.powsybl.iidm.network.test.SvcTestCaseFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * This class contains helper functions for tests.
@@ -22,9 +25,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @author Hugo Schindler {@literal <hugo.schindler at rte-france.com>}
  */
 public final class TestUtils {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TestUtils.class);
     private static final double EPSILON = 1e-6;
 
     private TestUtils() {
+        // Utility class
     }
 
     public static Network importNetwork(String networkResourcePath) {
@@ -43,12 +48,22 @@ public final class TestUtils {
             switch (rescaleMode) {
                 case ACER_METHODOLOGY -> assertEquals(Math.abs(decomposedFlow.getAcTerminal1ReferenceFlow()), decomposedFlow.getTotalFlow(), EPSILON);
                 case PROPORTIONAL -> assertEquals(decomposedFlow.getMaxAbsAcFlow(), decomposedFlow.getTotalFlow(), EPSILON);
-                default -> assertEquals(Math.abs(decomposedFlow.getDcReferenceFlow()), decomposedFlow.getTotalFlow(), EPSILON);
+                default -> assertEqualsWithoutRescaling(xnec, decomposedFlow);
             }
         }
     }
 
-    static double getLossOnBus(Network network, Bus bus) {
+    private static void assertEqualsWithoutRescaling(String xnec, DecomposedFlow decomposedFlow) {
+        if (Double.isNaN(decomposedFlow.getDcReferenceFlow())) {
+            LOGGER.error("XNEC \"{}\" is probably not connected", xnec); // TODO: should we decompose such xnecs ?
+        } else if (decomposedFlow.getTotalFlow() == 0) {
+            LOGGER.error("XNEC \"{}\" is outside main synchronous component", xnec); // TODO: should we decompose such xnecs ?
+        } else {
+            assertEquals(Math.abs(decomposedFlow.getDcReferenceFlow()), decomposedFlow.getTotalFlow(), EPSILON);
+        }
+    }
+
+    public static double getLossOnBus(Network network, Bus bus) {
         return network.getBranchStream()
             .filter(branch -> terminalIsSendingPowerToBus(branch.getTerminal1(), bus) || terminalIsSendingPowerToBus(branch.getTerminal2(), bus))
             .mapToDouble(branch -> branch.getTerminal1().getP() + branch.getTerminal2().getP())
@@ -57,5 +72,71 @@ public final class TestUtils {
 
     private static boolean terminalIsSendingPowerToBus(Terminal terminal, Bus bus) {
         return terminal.getBusBreakerView().getBus() == bus && terminal.getP() > 0;
+    }
+
+    public static Network getMicroGridNetworkWithBusBarSectionOnly() {
+        Network network = Importers.importData("CGMES", CgmesConformity3ModifiedCatalog.microGridBE3DanglingLinesSameBoundary1Disconnected().dataSource(), null);
+        network.getShuntCompensator("d771118f-36e9-4115-a128-cc3d9ce3e3da").remove();
+        network.getShuntCompensator("002b0a40-3957-46db-b84a-30420083558f").remove();
+        assertEquals(5, network.getBusbarSectionCount());
+        assertEquals(0, network.getShuntCompensatorCount());
+        assertEquals(0, network.getStaticVarCompensatorCount());
+        return network;
+    }
+
+    public static Network getMicroGridNetworkWithShuntCompensatorOnly() {
+        Network network = Importers.importData("CGMES", CgmesConformity3ModifiedCatalog.microGridBE3DanglingLinesSameBoundary1Disconnected().dataSource(), null);
+        network.getBusbarSection("5caf27ed-d2f8-458a-834a-6b3193a982e6").remove();
+        network.getBusbarSection("64901aec-5a8a-4bcb-8ca7-a3ddbfcd0e6c").remove();
+        network.getBusbarSection("364c9ca2-0d1d-4363-8f46-e586f8f66a8c").remove();
+        network.getBusbarSection("ef45b632-3028-4afe-bc4c-a4fa323d83fe").remove();
+        network.getBusbarSection("fd649fe1-bdf5-4062-98ea-bbb66f50402d").remove();
+        assertEquals(0, network.getBusbarSectionCount());
+        assertEquals(2, network.getShuntCompensatorCount());
+        assertEquals(0, network.getStaticVarCompensatorCount());
+        return network;
+    }
+
+    public static Network getNetworkWithStaticVarCompensatorOnly() {
+        Network network = SvcTestCaseFactory.create();
+        assertEquals(0, network.getBusbarSectionCount());
+        assertEquals(0, network.getShuntCompensatorCount());
+        assertEquals(1, network.getStaticVarCompensatorCount());
+        return network;
+    }
+
+    public static void validateFlowDecomposition(FlowDecompositionResults flowDecompositionResults,
+                                          String id,
+                                          String branchId,
+                                          String contingencyId,
+                                          Country country1,
+                                          Country country2,
+                                          double acReferenceFlow,
+                                          double dcReferenceFlow,
+                                          double allocatedFlow,
+                                          double xNodeFlow,
+                                          double pstFlow,
+                                          double internalFlow,
+                                          double loopFlowBe,
+                                          double loopFlowDe,
+                                          double loopFLowFr,
+                                          double loopFlowNl) {
+        DecomposedFlow l1 = flowDecompositionResults.getDecomposedFlowMap().get(id);
+        assertNotNull(l1);
+        assertEquals(id, l1.getId());
+        assertEquals(branchId, l1.getBranchId());
+        assertEquals(contingencyId, l1.getContingencyId());
+        assertEquals(country1, l1.getCountry1());
+        assertEquals(country2, l1.getCountry2());
+        assertEquals(acReferenceFlow, l1.getAcTerminal1ReferenceFlow(), EPSILON);
+        assertEquals(dcReferenceFlow, l1.getDcReferenceFlow(), EPSILON);
+        assertEquals(allocatedFlow, l1.getAllocatedFlow(), EPSILON);
+        assertEquals(xNodeFlow, l1.getXNodeFlow(), EPSILON);
+        assertEquals(pstFlow, l1.getPstFlow(), EPSILON);
+        assertEquals(internalFlow, l1.getInternalFlow(), EPSILON);
+        assertEquals(loopFlowBe, l1.getLoopFlow(Country.BE), EPSILON);
+        assertEquals(loopFlowDe, l1.getLoopFlow(Country.DE), EPSILON);
+        assertEquals(loopFLowFr, l1.getLoopFlow(Country.FR), EPSILON);
+        assertEquals(loopFlowNl, l1.getLoopFlow(Country.NL), EPSILON);
     }
 }

--- a/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/TestCase16NodesWithHvdc.xiidm
+++ b/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/TestCase16NodesWithHvdc.xiidm
@@ -1,0 +1,378 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_5" id="TestCase16Nodes" caseDate="2021-08-27T17:22:10.856+02:00" forecastDistance="0" sourceFormat="UCTE">
+    <iidm:substation id="BBE1AA" country="BE">
+        <iidm:voltageLevel id="BBE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE1AA11">
+                    <iidm:property name="geographicalName" value="BE1"/>
+                </iidm:bus>
+                <iidm:bus id="BBE4AA11">
+                    <iidm:property name="geographicalName" value="BE4"/>
+                </iidm:bus>
+                <iidm:switch id="BBE1AA11 BBE4AA11 1" kind="BREAKER" retained="true" open="false" bus1="BBE1AA11" bus2="BBE4AA11">
+                    <iidm:property name="orderCode" value="1"/>
+                    <iidm:property name="currentLimit" value="2000"/>
+                </iidm:switch>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE1AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="BBE1AA11" connectableBus="BBE1AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="BBE4AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="0.0" bus="BBE4AA11" connectableBus="BBE4AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE1AA11_load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="BBE1AA11" connectableBus="BBE1AA11"/>
+            <iidm:load id="BBE4AA11_load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="BBE4AA11" connectableBus="BBE4AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="BBE2AA" country="BE">
+        <iidm:voltageLevel id="BBE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="BBE2AA11">
+                    <iidm:property name="geographicalName" value="BE2"/>
+                </iidm:bus>
+                <iidm:bus id="BBE3AA11">
+                    <iidm:property name="geographicalName" value="BE3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="BBE2AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="0.0" bus="BBE2AA11" connectableBus="BBE2AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="BBE3AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="0.0" bus="BBE3AA11" connectableBus="BBE3AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="BBE2AA11_load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="BBE2AA11" connectableBus="BBE2AA11"/>
+            <iidm:load id="BBE3AA11_load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="BBE3AA11" connectableBus="BBE3AA11"/>
+            <iidm:vscConverterStation id="BBE2AA1_vsc" voltageRegulatorOn="true" lossFactor="1.0" voltageSetpoint="400.0" reactivePowerSetpoint="-150.0" bus="BBE2AA11" connectableBus="BBE2AA11">
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="150"/>
+            </iidm:vscConverterStation>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="BBE2AA11 BBE3AA11 1" r="0.0" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="BBE2AA11" connectableBus1="BBE2AA11" voltageLevelId1="BBE2AA1" bus2="BBE3AA11" connectableBus2="BBE3AA11" voltageLevelId2="BBE2AA1">
+            <iidm:property name="nomimalPower" value="1000.0"/>
+            <iidm:property name="elementName" value="PST"/>
+            <iidm:phaseTapChanger lowTapPosition="-16" tapPosition="0" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.22764253616333"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.839110374450684"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.450444221496582"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.061652183532715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.672743797302246"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.283727645874023"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.894613027572632"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.5054078102111816"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.116122007369995"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.726764440536499"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.337343454360962"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.9478689432144165"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.5583491325378418"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.1687933206558228"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.77921062707901"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.38960981369018555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.38960981369018555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.77921062707901"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.1687933206558228"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.5583491325378418"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.9478689432144165"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.337343454360962"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.726764440536499"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.116122007369995"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.5054078102111816"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.894613027572632"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.283727645874023"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.672743797302246"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.061652183532715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.450444221496582"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.839110374450684"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.22764253616333"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="2000.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="DDE1AA" country="DE">
+        <iidm:voltageLevel id="DDE1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE1AA11">
+                    <iidm:property name="geographicalName" value="DE1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE1AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2500.0" targetV="400.0" targetQ="0.0" bus="DDE1AA11" connectableBus="DDE1AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE1AA11_load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="DDE1AA11" connectableBus="DDE1AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE2AA" country="DE">
+        <iidm:voltageLevel id="DDE2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE2AA11">
+                    <iidm:property name="geographicalName" value="DE2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE2AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="DDE2AA11" connectableBus="DDE2AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE2AA11_load" loadType="UNDEFINED" p0="3000.0" q0="0.0" bus="DDE2AA11" connectableBus="DDE2AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="DDE3AA" country="DE">
+        <iidm:voltageLevel id="DDE3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="DDE3AA11">
+                    <iidm:property name="geographicalName" value="DE3"/>
+                </iidm:bus>
+                <iidm:bus id="DDE4AA11">
+                    <iidm:property name="geographicalName" value="DE3"/>
+                </iidm:bus>
+                <iidm:switch id="DDE3AA11 DDE4AA11 1" kind="BREAKER" retained="true" open="true" bus1="DDE3AA11" bus2="DDE4AA11">
+                    <iidm:property name="orderCode" value="1"/>
+                    <iidm:property name="currentLimit" value="2000"/>
+                </iidm:switch>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="DDE3AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="DDE3AA11" connectableBus="DDE3AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="DDE4AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="DDE4AA11" connectableBus="DDE4AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="DDE3AA11_load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="DDE3AA11" connectableBus="DDE3AA11"/>
+            <iidm:load id="DDE4AA11_load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="DDE4AA11" connectableBus="DDE4AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR1AA" country="FR">
+        <iidm:voltageLevel id="FFR1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR1AA11">
+                    <iidm:property name="geographicalName" value="FR1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR1AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="FFR1AA11" connectableBus="FFR1AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR1AA11_load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="FFR1AA11" connectableBus="FFR1AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR2AA" country="FR">
+        <iidm:voltageLevel id="FFR2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR2AA11">
+                    <iidm:property name="geographicalName" value="FR2"/>
+                </iidm:bus>
+                <iidm:bus id="FFR4AA11">
+                    <iidm:property name="geographicalName" value="FR4"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR2AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="FFR2AA11" connectableBus="FFR2AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:generator id="FFR4AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1000.0" targetV="400.0" targetQ="0.0" bus="FFR4AA11" connectableBus="FFR4AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR2AA11_load" loadType="UNDEFINED" p0="3500.0" q0="0.0" bus="FFR2AA11" connectableBus="FFR2AA11"/>
+            <iidm:load id="FFR4AA11_load" loadType="UNDEFINED" p0="2000.0" q0="0.0" bus="FFR4AA11" connectableBus="FFR4AA11"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="FFR2AA11 FFR4AA11 1" r="0.0" x="10.0" g="0.0" b="0.0" ratedU1="400.0" ratedU2="400.0" bus1="FFR2AA11" connectableBus1="FFR2AA11" voltageLevelId1="FFR2AA1" bus2="FFR4AA11" connectableBus2="FFR4AA11" voltageLevelId2="FFR2AA1">
+            <iidm:property name="nomimalPower" value="1000.0"/>
+            <iidm:property name="elementName" value="PST"/>
+            <iidm:phaseTapChanger lowTapPosition="-16" tapPosition="5" regulationMode="FIXED_TAP">
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-6.22764253616333"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.839110374450684"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.450444221496582"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-5.061652183532715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.672743797302246"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-4.283727645874023"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.894613027572632"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.5054078102111816"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-3.116122007369995"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.726764440536499"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-2.337343454360962"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.9478689432144165"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.5583491325378418"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-1.1687933206558228"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.77921062707901"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="-0.38960981369018555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.0"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.38960981369018555"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="0.77921062707901"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.1687933206558228"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.5583491325378418"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="1.9478689432144165"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.337343454360962"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="2.726764440536499"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.116122007369995"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.5054078102111816"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="3.894613027572632"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.283727645874023"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="4.672743797302246"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.061652183532715"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.450444221496582"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="5.839110374450684"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0" alpha="6.22764253616333"/>
+            </iidm:phaseTapChanger>
+            <iidm:currentLimits2 permanentLimit="2000.0"/>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:substation id="FFR3AA" country="FR">
+        <iidm:voltageLevel id="FFR3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR3AA11">
+                    <iidm:property name="geographicalName" value="FR3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR3AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="3000.0" targetV="400.0" targetQ="0.0" bus="FFR3AA11" connectableBus="FFR3AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR3AA11_load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="FFR3AA11" connectableBus="FFR3AA11"/>
+            <iidm:vscConverterStation id="FFR3AA1_vsc" voltageRegulatorOn="true" lossFactor="1.0" voltageSetpoint="400.0" reactivePowerSetpoint="-150.0" bus="FFR3AA11" connectableBus="FFR3AA11">
+                <iidm:minMaxReactiveLimits minQ="-150" maxQ="150"/>
+            </iidm:vscConverterStation>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="FFR5AA" country="FR">
+        <iidm:voltageLevel id="FFR5AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="FFR5AA11">
+                    <iidm:property name="geographicalName" value="FR5"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="FFR5AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="FFR5AA11" connectableBus="FFR5AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="FFR5AA11_load" loadType="UNDEFINED" p0="1500.0" q0="0.0" bus="FFR5AA11" connectableBus="FFR5AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL1AA" country="NL">
+        <iidm:voltageLevel id="NNL1AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL1AA11">
+                    <iidm:property name="geographicalName" value="NL1"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL1AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="1500.0" targetV="400.0" targetQ="0.0" bus="NNL1AA11" connectableBus="NNL1AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL1AA11_load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL1AA11" connectableBus="NNL1AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL2AA" country="NL">
+        <iidm:voltageLevel id="NNL2AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL2AA11">
+                    <iidm:property name="geographicalName" value="NL2"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL2AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="500.0" targetV="400.0" targetQ="0.0" bus="NNL2AA11" connectableBus="NNL2AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL2AA11_load" loadType="UNDEFINED" p0="1000.0" q0="0.0" bus="NNL2AA11" connectableBus="NNL2AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="NNL3AA" country="NL">
+        <iidm:voltageLevel id="NNL3AA1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NNL3AA11">
+                    <iidm:property name="geographicalName" value="NL3"/>
+                </iidm:bus>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="NNL3AA11_generator" energySource="OTHER" minP="-9000.0" maxP="9000.0" voltageRegulatorOn="true" targetP="2000.0" targetV="400.0" targetQ="0.0" bus="NNL3AA11" connectableBus="NNL3AA11">
+                <iidm:minMaxReactiveLimits minQ="-9000.0" maxQ="9000.0"/>
+            </iidm:generator>
+            <iidm:load id="NNL3AA11_load" loadType="UNDEFINED" p0="2500.0" q0="0.0" bus="NNL3AA11" connectableBus="NNL3AA11"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="BBE1AA11 BBE2AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA11" connectableBus1="BBE1AA11" voltageLevelId1="BBE1AA1" bus2="BBE2AA11" connectableBus2="BBE2AA11" voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA11 BBE3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA11" connectableBus1="BBE1AA11" voltageLevelId1="BBE1AA1" bus2="BBE3AA11" connectableBus2="BBE3AA11" voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA11 BBE3AA11 2" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA11" connectableBus1="BBE1AA11" voltageLevelId1="BBE1AA1" bus2="BBE3AA11" connectableBus2="BBE3AA11" voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE3AA11 BBE4AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE3AA11" connectableBus1="BBE3AA11" voltageLevelId1="BBE2AA1" bus2="BBE4AA11" connectableBus2="BBE4AA11" voltageLevelId2="BBE1AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA11 FFR2AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA11" connectableBus1="FFR1AA11" voltageLevelId1="FFR1AA1" bus2="FFR2AA11" connectableBus2="FFR2AA11" voltageLevelId2="FFR2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA11 FFR3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA11" connectableBus1="FFR1AA11" voltageLevelId1="FFR1AA1" bus2="FFR3AA11" connectableBus2="FFR3AA11" voltageLevelId2="FFR3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA11 FFR4AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR1AA11" connectableBus1="FFR1AA11" voltageLevelId1="FFR1AA1" bus2="FFR4AA11" connectableBus2="FFR4AA11" voltageLevelId2="FFR2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR1AA11 FFR5AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" connectableBus1="FFR1AA11" voltageLevelId1="FFR1AA1" connectableBus2="FFR5AA11" voltageLevelId2="FFR5AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA11 FFR3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA11" connectableBus1="FFR2AA11" voltageLevelId1="FFR2AA1" bus2="FFR3AA11" connectableBus2="FFR3AA11" voltageLevelId2="FFR3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA11 FFR3AA11 2" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA11" connectableBus1="FFR2AA11" voltageLevelId1="FFR2AA1" bus2="FFR3AA11" connectableBus2="FFR3AA11" voltageLevelId2="FFR3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR3AA11 FFR5AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR3AA11" connectableBus1="FFR3AA11" voltageLevelId1="FFR3AA1" bus2="FFR5AA11" connectableBus2="FFR5AA11" voltageLevelId2="FFR5AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA11 DDE2AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA11" connectableBus1="DDE1AA11" voltageLevelId1="DDE1AA1" bus2="DDE2AA11" connectableBus2="DDE2AA11" voltageLevelId2="DDE2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE1AA11 DDE4AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE1AA11" connectableBus1="DDE1AA11" voltageLevelId1="DDE1AA1" bus2="DDE4AA11" connectableBus2="DDE4AA11" voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA11 DDE3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA11" connectableBus1="DDE2AA11" voltageLevelId1="DDE2AA1" bus2="DDE3AA11" connectableBus2="DDE3AA11" voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA11 NNL2AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA11" connectableBus1="NNL1AA11" voltageLevelId1="NNL1AA1" bus2="NNL2AA11" connectableBus2="NNL2AA11" voltageLevelId2="NNL2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL1AA11 NNL3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL1AA11" connectableBus1="NNL1AA11" voltageLevelId1="NNL1AA1" bus2="NNL3AA11" connectableBus2="NNL3AA11" voltageLevelId2="NNL3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA11 NNL3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA11" connectableBus1="NNL2AA11" voltageLevelId1="NNL2AA1" bus2="NNL3AA11" connectableBus2="NNL3AA11" voltageLevelId2="NNL3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR4AA11 DDE1AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR4AA11" connectableBus1="FFR4AA11" voltageLevelId1="FFR2AA1" bus2="DDE1AA11" connectableBus2="DDE1AA11" voltageLevelId2="DDE1AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR4AA11 DDE4AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR4AA11" connectableBus1="FFR4AA11" voltageLevelId1="FFR2AA1" bus2="DDE4AA11" connectableBus2="DDE4AA11" voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="FFR2AA11 DDE3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="FFR2AA11" connectableBus1="FFR2AA11" voltageLevelId1="FFR2AA1" bus2="DDE3AA11" connectableBus2="DDE3AA11" voltageLevelId2="DDE3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="DDE2AA11 NNL3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="DDE2AA11" connectableBus1="DDE2AA11" voltageLevelId1="DDE2AA1" bus2="NNL3AA11" connectableBus2="NNL3AA11" voltageLevelId2="NNL3AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="NNL2AA11 BBE3AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="NNL2AA11" connectableBus1="NNL2AA11" voltageLevelId1="NNL2AA1" bus2="BBE3AA11" connectableBus2="BBE3AA11" voltageLevelId2="BBE2AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE1AA11 FFR5AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE1AA11" connectableBus1="BBE1AA11" voltageLevelId1="BBE1AA1" bus2="FFR5AA11" connectableBus2="FFR5AA11" voltageLevelId2="FFR5AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:line id="BBE4AA11 FFR5AA11 1" r="0.0" x="10.0" g1="0.0" b1="0.0" g2="0.0" b2="0.0" bus1="BBE4AA11" connectableBus1="BBE4AA11" voltageLevelId1="BBE1AA1" bus2="FFR5AA11" connectableBus2="FFR5AA11" voltageLevelId2="FFR5AA1">
+        <iidm:currentLimits1 permanentLimit="2000.0"/>
+        <iidm:currentLimits2 permanentLimit="2000.0"/>
+    </iidm:line>
+    <iidm:hvdcLine id="BBE2AA11 FFR3AA11 1" r="0.25" nominalV="1000.0" convertersMode="SIDE_1_RECTIFIER_SIDE_2_INVERTER" activePowerSetpoint="0.0" maxP="2000.0" converterStation1="BBE2AA1_vsc" converterStation2="FFR3AA1_vsc"/>
+</iidm:network>

--- a/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/lossesCompensatorLineConnectedToOneSide.xiidm
+++ b/flow-decomposition/src/test/resources/com/powsybl/flow_decomposition/lossesCompensatorLineConnectedToOneSide.xiidm
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_12" id="test" caseDate="2024-05-27T13:09:06.308Z" forecastDistance="0" sourceFormat="code" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="b1_s" country="FR">
+        <iidm:voltageLevel id="b1_vl" nominalV="1.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="b1"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="g1" energySource="OTHER" minP="0.0" maxP="6.0" voltageRegulatorOn="true" targetP="3.0" targetV="1.0" bus="b1" connectableBus="b1" p="-3.0" q="0.0">
+                <iidm:minMaxReactiveLimits minQ="-1.7976931348623157E308" maxQ="1.7976931348623157E308"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="b2_s" country="BE">
+        <iidm:voltageLevel id="b2_vl" nominalV="1.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="b2"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="d2" loadType="UNDEFINED" p0="2.0" q0="0.0" bus="b2" connectableBus="b2" p="2.0" q="0.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:substation id="b3_s" country="BE">
+        <iidm:voltageLevel id="b3_vl" nominalV="1.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="b3"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="d3" loadType="UNDEFINED" p0="1" q0="0.0" bus="b3" connectableBus="b3" p="1" q="0.0"/>
+        </iidm:voltageLevel>
+    </iidm:substation>
+    <iidm:line id="l21" r="0.01" x="0.1" g1="0.0" b1="0.5" g2="0.0" b2="0.5" voltageLevelId1="b2_vl" bus1="b2" connectableBus1="b2" voltageLevelId2="b1_vl" bus2="b1" connectableBus2="b1"/>
+    <iidm:line id="l32" r="0.01" x="0.1" g1="0.0" b1="0.5" g2="0.0" b2="0.5" voltageLevelId1="b3_vl" connectableBus1="b3" voltageLevelId2="b2_vl" bus2="b2" connectableBus2="b2"/>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
- Docs lacking
- Refactoring for observers in flow decompostion computer and NetworkUtils
- Losses compensator
   - We don't compensate losses for branches that are connected to only one side
   - Bug in edge case where both P1 and P2 are positive (one is really close to zero) and the sending terminal is incorrectly identified
   - Set loads created to compensate losses to fictitious (will make a difference when https://github.com/powsybl/powsybl-open-loadflow/pull/1028 is merged)


**What is the new behavior (if this is a feature change)?**
- Docs added
- Issue created #150 
- Refactored observers in flow decompostion computer and NetworkUtils
- Losses compensator
   - Compensate losses for branches connected to only one side
   - Sending terminal is always correctly identified
   - Slack won't be distributed on fictitious loads created by losses compensator


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No