### PR TITLE
Add build-docs folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ org.sonarlint.eclipse.core.prefs
 
 # Log files
 powsybl.log
+
+# Generated readthedocs pages
+build-docs/


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
Quality
This PR adds the build-docs folder, generated after building documentation, to the .gitignore file.