### PR TITLE
Fix test dependencies declared as runtime or compile dependencies

### DIFF
--- a/balances-adjustment/pom.xml
+++ b/balances-adjustment/pom.xml
@@ -49,14 +49,12 @@
             <artifactId>powsybl-time-series-api</artifactId>
         </dependency>
 
-        <!-- Runtime dependencies -->
+        <!-- Test dependencies -->
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
-
-        <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/balances-adjustment/pom.xml
+++ b/balances-adjustment/pom.xml
@@ -34,10 +34,6 @@
         <!-- Compile dependencies -->
         <dependency>
             <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-cgmes-extensions</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-commons</artifactId>
         </dependency>
         <dependency>
@@ -104,6 +100,11 @@
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-ucte-converter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-cgmes-extensions</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/entsoe-cgmes-balances-adjustment/pom.xml
+++ b/entsoe-cgmes-balances-adjustment/pom.xml
@@ -57,6 +57,11 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/flow-decomposition/pom.xml
+++ b/flow-decomposition/pom.xml
@@ -45,33 +45,32 @@
             <artifactId>ejml-all</artifactId>
             <version>${ejml.version}</version>
         </dependency>
-        <!-- Runtime dependencies -->
+        <!-- Test dependencies -->
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-impl</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-iidm-serde</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.powsybl</groupId>
-            <artifactId>powsybl-open-loadflow</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
             <artifactId>powsybl-ucte-converter</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <scope>runtime</scope>
+            <scope>test</scope>
         </dependency>
-        <!-- Test dependencies -->
+        <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-open-loadflow</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.jimfs</groupId>
             <artifactId>jimfs</artifactId>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
* balances-adjustment module declares:
  * compile dependency on `powsybl-cgmes-extensions`
  * runtime dependency on `powsybl-iidm-impl`
* flow-decomposition module declares:
  * runtime dependency on `powsybl-iidm-impl`
  * runtime dependency on `powsybl-iidm-serde`
  * runtime dependency on `powsybl-open-loadflow`
  * runtime dependency on `powsybl-ucte-converter`

**What is the new behavior (if this is a feature change)?**
above listed dependencies are only test dependencies


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [X] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->

You may need to add the following dependencies to your project since they are no more included via transitivity:
- `com.powsybl:powsybl-cgmes-extensions`;
- `com.powsybl:powsybl-iidm-impl`;
- `com.powsybl:powsybl-ucte-converter`;
- `com.powsybl:powsybl-open-loadflow`.

Also note that you need SecurityAnalysis API and LoadFlow API implementations to use this project as a dependency.
Before this PR, `powsybl-open-loadflow` was automatically included to downstream projects (transitive dependency). With this PR, it is not the case anymore. **If you don't use other implementations, you will have to add `powsybl-open-loadflow` as a dependency to have the same behavior as before.**
