### PR TITLE
Fix dead links to powsybl.org documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,10 +95,11 @@ html_css_files = ['styles/styles.css']
 
 todo_include_todos = True
 
-# Links to external documentations : python 3 and pandas
+# Links to external documentations
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'pandas': ('https://pandas.pydata.org/docs', None),
+    'powsyblcore': ('https://powsybl.readthedocs.io/projects/powsybl-core/en/latest/', None),
 }
 
 # Generate one file per method

--- a/docs/flow_decomposition/algorithm-description.md
+++ b/docs/flow_decomposition/algorithm-description.md
@@ -85,7 +85,7 @@ where:
 In order to assess the linear impact (implied by the DC approximation) of each nodal injection and phase shift transformer
 on the network elements' flow, a sensitivity analysis is run.
 
-The following matrices are calculated using [sensitivity analysis](https://www.powsybl.org/pages/documentation/simulation/sensitivity/) API:
+The following matrices are calculated using [sensitivity analysis](inv:powsyblcore:std:doc#simulation/sensitivity/index) API:
 - $\mathrm{PTDF}$ is the matrix of the sensitivity of the network element flow to each network injection shift,
 - $\mathrm{PSDF}$ is the matrix of the sensitivity of the network element flow to each phase shift transformer tap angle change,
 

--- a/docs/flow_decomposition/configuration.md
+++ b/docs/flow_decomposition/configuration.md
@@ -17,4 +17,4 @@
 Any implementation of load flow provider and sensitivity analysis provider can be used, as the entire algorithm only
 relies on common loadflow API and sensitivity analysis API.
 
-Thus, flow decomposition algorithm relies on [load flow parameters](https://www.powsybl.org/pages/documentation/simulation/powerflow/) and [sensitivity analysis parameters](https://www.powsybl.org/pages/documentation/simulation/sensitivity/).
+Thus, flow decomposition algorithm relies on [load flow parameters](inv:powsyblcore:*:*#loadflow-generic-parameters) and [sensitivity analysis parameters](inv:powsyblcore:*:*#sensitivity-generic-parameter).

--- a/docs/flow_decomposition/flow-decomposition-inputs.md
+++ b/docs/flow_decomposition/flow-decomposition-inputs.md
@@ -2,7 +2,7 @@
 
 ## Network
 
-The first input of the flow decomposition algorithm is a network. As this simulation uses [power flow](https://www.powsybl.org/pages/documentation/simulation/powerflow/)
+The first input of the flow decomposition algorithm is a network. As this simulation uses [power flow](inv:powsyblcore:std:doc#simulation/loadflow/index)
 simulations for losses compensation, this network should converge.
 
 Any available source can be used as a valid input for flow decomposition (including UCTE, CGMES, XIIDM).


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In the documentation, there are some links to recently removed documentation from powsybl.org.


**What is the new behavior (if this is a feature change)?**
This PR changes the links to redirect to the readthedocs.

