### PR TITLE
Distribute losses evenly when calculating the net position for paired dangling lines

### DIFF
--- a/docs/flow_decomposition/algorithm-description.md
+++ b/docs/flow_decomposition/algorithm-description.md
@@ -13,7 +13,9 @@ Below is the concrete description of the algorithm implemented in PowSyBl.
 Countries' net position computation is done once for all on base case using AC loadflow in the initial network, before any other alteration of the input.
 
 The net position of a country is calculated as the sum of the mean leaving flow of all AC and HVDC line interconnections
-(losses are shared equally between both countries)
+(losses are shared equally between both countries).
+
+Unpaired half lines contribute only to the net position of its physical terminal.
 
 ## Losses compensation
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/NetPositionComputer.java
@@ -30,24 +30,12 @@ class NetPositionComputer {
             if (countrySide1.equals(countrySide2)) {
                 return;
             }
-            if (branch instanceof TieLine tieLine) {
-                DanglingLine danglingLine1 = tieLine.getDanglingLine1();
-                DanglingLine danglingLine2 = tieLine.getDanglingLine2();
-                // danglinglines are paired but one of them is disconnected => treat them as unpaired
-                if (!danglingLine1.getTerminal().isConnected() || !danglingLine2.getTerminal().isConnected()) {
-                    Country country1 = NetworkUtil.getTerminalCountry(danglingLine1.getTerminal());
-                    addLeavingFlow(netPositions, danglingLine1, country1);
-                    Country country2 = NetworkUtil.getTerminalCountry(danglingLine2.getTerminal());
-                    addLeavingFlow(netPositions, danglingLine2, country2);
-                    return;
-                }
-            }
             addLeavingFlow(netPositions, branch, countrySide1);
             addLeavingFlow(netPositions, branch, countrySide2);
         });
 
         // unpaired dangling lines
-        network.getDanglingLineStream().filter(danglingLine -> !danglingLine.isPaired()).forEach(danglingLine -> {
+        network.getDanglingLineStream(DanglingLineFilter.UNPAIRED).forEach(danglingLine -> {
             Country country = NetworkUtil.getTerminalCountry(danglingLine.getTerminal());
             addLeavingFlow(netPositions, danglingLine, country);
         });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Losses for paired dangling lines are not split equally in net position calculation. As a consequence, the sum of all net positions of a closed network is not 0.


**What is the new behavior (if this is a feature change)?**
Paired dangling lines (tie lines) are treated like normal lines in net position calculation.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No