### PR TITLE
Add parameter to output flow decomposition results for paired dangling lines

### DIFF
--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlow.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/DecomposedFlow.java
@@ -43,7 +43,7 @@ public class DecomposedFlow {
         this.branchId = Objects.requireNonNull(builder.branchId);
         this.contingencyId = Objects.requireNonNull(builder.contingencyId);
         this.country1 = Objects.requireNonNull(builder.country1);
-        this.country2 = Objects.requireNonNull(builder.country2);
+        this.country2 = builder.country2;
         this.acTerminal1ReferenceFlow = builder.acTerminal1ReferenceFlow;
         this.acTerminal2ReferenceFlow = builder.acTerminal2ReferenceFlow;
         this.dcReferenceFlow = builder.dcReferenceFlow;

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -163,7 +163,7 @@ public class FlowDecompositionComputer {
         computeAllocatedAndLoopFlows(flowDecompositionResultsBuilder, nodalInjectionsMatrix, ptdfMatrix);
         computePstFlows(network, flowDecompositionResultsBuilder, networkMatrixIndexes, psdfMatrix);
 
-        flowDecompositionResultsBuilder.build(decomposedFlowRescaler, network);
+        flowDecompositionResultsBuilder.build(decomposedFlowRescaler, network, parameters.getEnableResultsForPairedHalfLines());
     }
 
     public void addObserver(FlowDecompositionObserver observer) {
@@ -179,22 +179,20 @@ public class FlowDecompositionComputer {
     }
 
     private void saveAcReferenceFlows(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        // TODO parameters.getEnableResultsForPairedHalfLine()
         Map<String, Double> acTerminal1ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, true, TwoSides.ONE);
         Map<String, Double> acTerminal2ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, true, TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcTerminal1ReferenceFlow(acTerminal1ReferenceFlows);
         flowDecompositionResultBuilder.saveAcTerminal2ReferenceFlow(acTerminal2ReferenceFlows);
-        observers.computedAcFlows(network, loadFlowServiceAcResult);
+        observers.computedAcFlows(network, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines());
         observers.computedAcNodalInjections(network, loadFlowServiceAcResult.fallbackHasBeenActivated());
     }
 
     private void saveAcCurrents(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        // TODO parameters.getEnableResultsForPairedHalfLine()
         Map<String, Double> acTerminal1Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, true, TwoSides.ONE);
         Map<String, Double> acTerminal2Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, true, TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcCurrentTerminal1(acTerminal1Currents);
         flowDecompositionResultBuilder.saveAcCurrentTerminal2(acTerminal2Currents);
-        observers.computedAcCurrents(network, loadFlowServiceAcResult);
+        observers.computedAcCurrents(network, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines());
     }
 
     private Map<Country, Double> getZonesNetPosition(Network network) {
@@ -233,9 +231,8 @@ public class FlowDecompositionComputer {
     }
 
     private void saveDcReferenceFlow(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList) {
-        // TODO parameters.getEnableResultsForPairedHalfLine()
         flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlows(xnecList, true, TwoSides.ONE));
-        observers.computedDcFlows(network);
+        observers.computedDcFlows(network, parameters.getEnableResultsForPairedHalfLines());
         observers.computedDcNodalInjections(network);
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -179,8 +179,9 @@ public class FlowDecompositionComputer {
     }
 
     private void saveAcReferenceFlows(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        Map<String, Double> acTerminal1ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, TwoSides.ONE);
-        Map<String, Double> acTerminal2ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, TwoSides.TWO);
+        // TODO parameters.getEnableResultsForPairedHalfLine()
+        Map<String, Double> acTerminal1ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, true, TwoSides.ONE);
+        Map<String, Double> acTerminal2ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, true, TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcTerminal1ReferenceFlow(acTerminal1ReferenceFlows);
         flowDecompositionResultBuilder.saveAcTerminal2ReferenceFlow(acTerminal2ReferenceFlows);
         observers.computedAcFlows(network, loadFlowServiceAcResult);
@@ -188,8 +189,9 @@ public class FlowDecompositionComputer {
     }
 
     private void saveAcCurrents(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        Map<String, Double> acTerminal1Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, TwoSides.ONE);
-        Map<String, Double> acTerminal2Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, TwoSides.TWO);
+        // TODO parameters.getEnableResultsForPairedHalfLine()
+        Map<String, Double> acTerminal1Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, true, TwoSides.ONE);
+        Map<String, Double> acTerminal2Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, true, TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcCurrentTerminal1(acTerminal1Currents);
         flowDecompositionResultBuilder.saveAcCurrentTerminal2(acTerminal2Currents);
         observers.computedAcCurrents(network, loadFlowServiceAcResult);
@@ -231,7 +233,8 @@ public class FlowDecompositionComputer {
     }
 
     private void saveDcReferenceFlow(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList) {
-        flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlow(xnecList, TwoSides.ONE));
+        // TODO parameters.getEnableResultsForPairedHalfLine()
+        flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlows(xnecList, true, TwoSides.ONE));
         observers.computedDcFlows(network);
         observers.computedDcNodalInjections(network);
     }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -179,8 +179,8 @@ public class FlowDecompositionComputer {
     }
 
     private void saveAcReferenceFlows(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        Map<String, Double> acTerminal1ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, true, TwoSides.ONE);
-        Map<String, Double> acTerminal2ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, true, TwoSides.TWO);
+        Map<String, Double> acTerminal1ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines(), TwoSides.ONE);
+        Map<String, Double> acTerminal2ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines(), TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcTerminal1ReferenceFlow(acTerminal1ReferenceFlows);
         flowDecompositionResultBuilder.saveAcTerminal2ReferenceFlow(acTerminal2ReferenceFlows);
         observers.computedAcFlows(network, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines());
@@ -188,8 +188,8 @@ public class FlowDecompositionComputer {
     }
 
     private void saveAcCurrents(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        Map<String, Double> acTerminal1Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, true, TwoSides.ONE);
-        Map<String, Double> acTerminal2Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, true, TwoSides.TWO);
+        Map<String, Double> acTerminal1Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines(), TwoSides.ONE);
+        Map<String, Double> acTerminal2Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines(), TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcCurrentTerminal1(acTerminal1Currents);
         flowDecompositionResultBuilder.saveAcCurrentTerminal2(acTerminal2Currents);
         observers.computedAcCurrents(network, loadFlowServiceAcResult, parameters.getEnableResultsForPairedHalfLines());
@@ -231,7 +231,7 @@ public class FlowDecompositionComputer {
     }
 
     private void saveDcReferenceFlow(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList) {
-        flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlows(xnecList, true, TwoSides.ONE));
+        flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlows(xnecList, parameters.getEnableResultsForPairedHalfLines(), TwoSides.ONE));
         observers.computedDcFlows(network, parameters.getEnableResultsForPairedHalfLines());
         observers.computedDcNodalInjections(network);
     }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -88,9 +88,10 @@ public class FlowDecompositionObserverList {
             return;
         }
 
+        // TODO parameters.getEnableResultsForPairedHalfLine()
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcFlowsTerminal1(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.ONE));
-            o.computedAcFlowsTerminal2(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.TWO));
+            o.computedAcFlowsTerminal1(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.ONE));
+            o.computedAcFlowsTerminal2(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.TWO));
         }
     }
 
@@ -99,8 +100,9 @@ public class FlowDecompositionObserverList {
             return;
         }
 
+        // TODO parameters.getEnableResultsForPairedHalfLine()
         for (FlowDecompositionObserver o : observers) {
-            o.computedDcFlows(FlowComputerUtils.getTerminalReferenceFlow(network.getBranchStream().toList(), TwoSides.ONE));
+            o.computedDcFlows(FlowComputerUtils.getTerminalReferenceFlows(network.getBranchStream().toList(), true, TwoSides.ONE));
         }
     }
 
@@ -109,9 +111,10 @@ public class FlowDecompositionObserverList {
             return;
         }
 
+        // TODO parameters.getEnableResultsForPairedHalfLine()
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcCurrentsTerminal1(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.ONE));
-            o.computedAcCurrentsTerminal2(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.TWO));
+            o.computedAcCurrentsTerminal1(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.ONE));
+            o.computedAcCurrentsTerminal2(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.TWO));
         }
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -83,38 +83,35 @@ public class FlowDecompositionObserverList {
         sendMatrix(FlowDecompositionObserver::computedPsdfMatrix, matrix);
     }
 
-    public void computedAcFlows(Network network, Result loadFlowServiceAcResult) {
+    public void computedAcFlows(Network network, Result loadFlowServiceAcResult, boolean enableResultsForPairedHalfLines) {
         if (observers.isEmpty()) {
             return;
         }
 
-        // TODO parameters.getEnableResultsForPairedHalfLine()
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcFlowsTerminal1(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.ONE));
-            o.computedAcFlowsTerminal2(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.TWO));
+            o.computedAcFlowsTerminal1(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, enableResultsForPairedHalfLines, TwoSides.ONE));
+            o.computedAcFlowsTerminal2(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, enableResultsForPairedHalfLines, TwoSides.TWO));
         }
     }
 
-    public void computedDcFlows(Network network) {
+    public void computedDcFlows(Network network, boolean enableResultsForPairedHalfLines) {
         if (observers.isEmpty()) {
             return;
         }
 
-        // TODO parameters.getEnableResultsForPairedHalfLine()
         for (FlowDecompositionObserver o : observers) {
-            o.computedDcFlows(FlowComputerUtils.getTerminalReferenceFlows(network.getBranchStream().toList(), true, TwoSides.ONE));
+            o.computedDcFlows(FlowComputerUtils.getTerminalReferenceFlows(network.getBranchStream().toList(), enableResultsForPairedHalfLines, TwoSides.ONE));
         }
     }
 
-    public void computedAcCurrents(Network network, Result loadFlowServiceAcResult) {
+    public void computedAcCurrents(Network network, Result loadFlowServiceAcResult, boolean enableResultsForPairedHalfLines) {
         if (observers.isEmpty()) {
             return;
         }
 
-        // TODO parameters.getEnableResultsForPairedHalfLine()
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcCurrentsTerminal1(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.ONE));
-            o.computedAcCurrentsTerminal2(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, true, TwoSides.TWO));
+            o.computedAcCurrentsTerminal1(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, enableResultsForPairedHalfLines, TwoSides.ONE));
+            o.computedAcCurrentsTerminal2(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, enableResultsForPairedHalfLines, TwoSides.TWO));
         }
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionParameters.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionParameters.java
@@ -27,6 +27,7 @@ public class FlowDecompositionParameters {
     public static final boolean DEFAULT_DC_FALLBACK_ENABLED_AFTER_AC_DIVERGENCE = ENABLE_DC_FALLBACK_AFTER_AC_DIVERGENCE;
     private static final int DEFAULT_SENSITIVITY_VARIABLE_BATCH_SIZE = 15000;
     public static final double DEFAULT_PROPORTIONAL_RESCALER_MIN_FLOW_TOLERANCE = 1E-6;
+    public static final boolean DEFAULT_ENABLE_RESULTS_FOR_PAIRED_HALF_LINES = false;
 
     public enum RescaleMode {
         NONE,
@@ -43,6 +44,7 @@ public class FlowDecompositionParameters {
     private double proportionalRescalerMinFlowTolerance;
     private boolean dcFallbackEnabledAfterAcDivergence;
     private int sensitivityVariableBatchSize;
+    private boolean enableResultsForPairedHalfLines;
 
     public static FlowDecompositionParameters load() {
         return load(PlatformConfig.defaultConfig());
@@ -65,6 +67,7 @@ public class FlowDecompositionParameters {
             parameters.setProportionalRescalerMinFlowTolerance(moduleConfig.getDoubleProperty("proportional-rescaler-min-flow-tolerance", DEFAULT_PROPORTIONAL_RESCALER_MIN_FLOW_TOLERANCE));
             parameters.setDcFallbackEnabledAfterAcDivergence(moduleConfig.getBooleanProperty("dc-fallback-enabled-after-ac-divergence", DEFAULT_DC_FALLBACK_ENABLED_AFTER_AC_DIVERGENCE));
             parameters.setSensitivityVariableBatchSize(moduleConfig.getIntProperty("sensitivity-variable-batch-size", DEFAULT_SENSITIVITY_VARIABLE_BATCH_SIZE));
+            parameters.setEnableResultsForPairedHalfLines(moduleConfig.getBooleanProperty("enable-results-for-paired-half-lines", DEFAULT_ENABLE_RESULTS_FOR_PAIRED_HALF_LINES));
         });
     }
 
@@ -76,6 +79,7 @@ public class FlowDecompositionParameters {
         this.proportionalRescalerMinFlowTolerance = DEFAULT_PROPORTIONAL_RESCALER_MIN_FLOW_TOLERANCE;
         this.dcFallbackEnabledAfterAcDivergence = DEFAULT_DC_FALLBACK_ENABLED_AFTER_AC_DIVERGENCE;
         this.sensitivityVariableBatchSize = DEFAULT_SENSITIVITY_VARIABLE_BATCH_SIZE;
+        this.enableResultsForPairedHalfLines = DEFAULT_ENABLE_RESULTS_FOR_PAIRED_HALF_LINES;
     }
 
     public FlowDecompositionParameters setEnableLossesCompensation(boolean enableLossesCompensation) {
@@ -138,5 +142,14 @@ public class FlowDecompositionParameters {
     public FlowDecompositionParameters setSensitivityVariableBatchSize(int sensitivityVariableBatchSize) {
         this.sensitivityVariableBatchSize = sensitivityVariableBatchSize;
         return this;
+    }
+
+    public FlowDecompositionParameters setEnableResultsForPairedHalfLines(boolean enableResultsForPairedHalfLines) {
+        this.enableResultsForPairedHalfLines = enableResultsForPairedHalfLines;
+        return this;
+    }
+
+    public boolean getEnableResultsForPairedHalfLines() {
+        return this.enableResultsForPairedHalfLines;
     }
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
@@ -89,14 +89,16 @@ public class FlowDecompositionResults {
                     if (!enableResultsForPairedHalfLine) {
                         return;
                     }
-                    TieLine tieLine = network.getTieLine(xnecId);
+                    TieLine tieLine = network.getTieLine(branchId);
                     if (tieLine == null) {
                         return;
                     }
                     DanglingLine danglingLine1 = tieLine.getDanglingLine1();
                     DanglingLine danglingLine2 = tieLine.getDanglingLine2();
-                    decomposedFlowMap.put(danglingLine1.getId(), createDecomposedFlowForHalfLine(danglingLine1, decomposedFlow, decomposedFlowRescaler, network));
-                    decomposedFlowMap.put(danglingLine2.getId(), createDecomposedFlowForHalfLine(danglingLine2, decomposedFlow, decomposedFlowRescaler, network));
+                    String halfXnec1Id = DecomposedFlow.getXnecId(contingencyId, danglingLine1.getId());
+                    String halfXnec2Id = DecomposedFlow.getXnecId(contingencyId, danglingLine2.getId());
+                    decomposedFlowMap.put(halfXnec1Id, createDecomposedFlowForHalfLine(danglingLine1, branchId, decomposedFlow, decomposedFlowRescaler, network));
+                    decomposedFlowMap.put(halfXnec2Id, createDecomposedFlowForHalfLine(danglingLine2, branchId, decomposedFlow, decomposedFlowRescaler, network));
                 });
         }
 
@@ -129,13 +131,13 @@ public class FlowDecompositionResults {
             return decomposedFlowRescaler.rescale(decomposedFlow, network);
         }
 
-        private DecomposedFlow createDecomposedFlowForHalfLine(DanglingLine danglingLine, Map<String, Double> allocatedAndLoopFlowMap, DecomposedFlowRescaler decomposedFlowRescaler, Network network) {
+        private DecomposedFlow createDecomposedFlowForHalfLine(DanglingLine danglingLine, String branchId, Map<String, Double> allocatedAndLoopFlowMap, DecomposedFlowRescaler decomposedFlowRescaler, Network network) {
             String danglingLineId = danglingLine.getId();
             Map<String, Double> loopFlowsMap = allocatedAndLoopFlowMap.entrySet().stream()
                     .filter(entry -> entry.getKey().startsWith(LOOP_FLOWS_COLUMN_PREFIX))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
             double allocatedFlow = allocatedAndLoopFlowMap.get(ALLOCATED_COLUMN_NAME);
-            double pstFlow = pstFlowMap.getOrDefault(danglingLineId, Collections.emptyMap()).getOrDefault(PST_COLUMN_NAME, NO_FLOW);
+            double pstFlow = pstFlowMap.getOrDefault(branchId, Collections.emptyMap()).getOrDefault(PST_COLUMN_NAME, NO_FLOW);
             double xNodeFlow = allocatedAndLoopFlowMap.getOrDefault(XNODE_COLUMN_NAME, NO_FLOW);
             Country country = NetworkUtil.getTerminalCountry(danglingLine.getTerminal());
             DecomposedFlow decomposedFlow = new DecomposedFlowBuilder()

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
@@ -81,8 +81,7 @@ public class FlowDecompositionResults {
             this.dcReferenceFlow = dcReferenceFlow;
         }
 
-        void build(DecomposedFlowRescaler decomposedFlowRescaler, Network network) {
-            boolean enableResultsForPairedHalfLine = true; // TODO
+        void build(DecomposedFlowRescaler decomposedFlowRescaler, Network network, boolean enableResultsForPairedHalfLine) {
             allocatedAndLoopFlowsMatrix.toMap()
                 .forEach((branchId, decomposedFlow) -> {
                     String xnecId = DecomposedFlow.getXnecId(contingencyId, branchId);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
@@ -86,19 +86,17 @@ public class FlowDecompositionResults {
                 .forEach((branchId, decomposedFlow) -> {
                     String xnecId = DecomposedFlow.getXnecId(contingencyId, branchId);
                     decomposedFlowMap.put(xnecId, createDecomposedFlow(branchId, decomposedFlow, decomposedFlowRescaler, network));
-                    if (!enableResultsForPairedHalfLine) {
-                        return;
+                    if (enableResultsForPairedHalfLine) {
+                        TieLine tieLine = network.getTieLine(branchId);
+                        if (tieLine != null) {
+                            DanglingLine danglingLine1 = tieLine.getDanglingLine1();
+                            DanglingLine danglingLine2 = tieLine.getDanglingLine2();
+                            String halfXnec1Id = DecomposedFlow.getXnecId(contingencyId, danglingLine1.getId());
+                            String halfXnec2Id = DecomposedFlow.getXnecId(contingencyId, danglingLine2.getId());
+                            decomposedFlowMap.put(halfXnec1Id, createDecomposedFlowForHalfLine(danglingLine1, branchId, decomposedFlow, decomposedFlowRescaler, network));
+                            decomposedFlowMap.put(halfXnec2Id, createDecomposedFlowForHalfLine(danglingLine2, branchId, decomposedFlow, decomposedFlowRescaler, network));
+                        }
                     }
-                    TieLine tieLine = network.getTieLine(branchId);
-                    if (tieLine == null) {
-                        return;
-                    }
-                    DanglingLine danglingLine1 = tieLine.getDanglingLine1();
-                    DanglingLine danglingLine2 = tieLine.getDanglingLine2();
-                    String halfXnec1Id = DecomposedFlow.getXnecId(contingencyId, danglingLine1.getId());
-                    String halfXnec2Id = DecomposedFlow.getXnecId(contingencyId, danglingLine2.getId());
-                    decomposedFlowMap.put(halfXnec1Id, createDecomposedFlowForHalfLine(danglingLine1, branchId, decomposedFlow, decomposedFlowRescaler, network));
-                    decomposedFlowMap.put(halfXnec2Id, createDecomposedFlowForHalfLine(danglingLine2, branchId, decomposedFlow, decomposedFlowRescaler, network));
                 });
         }
 

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionParametersTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionParametersTests.java
@@ -54,6 +54,7 @@ class FlowDecompositionParametersTests {
         assertEquals(FlowDecompositionParameters.DEFAULT_PROPORTIONAL_RESCALER_MIN_FLOW_TOLERANCE, parameters.getProportionalRescalerMinFlowTolerance(), EPSILON / 100);
         assertTrue(parameters.isDcFallbackEnabledAfterAcDivergence());
         assertEquals(15000, parameters.getSensitivityVariableBatchSize());
+        assertFalse(parameters.getEnableResultsForPairedHalfLines());
     }
 
     @Test
@@ -66,6 +67,7 @@ class FlowDecompositionParametersTests {
         mapModuleConfig.setStringProperty("proportional-rescaler-min-flow-tolerance", Double.toString(1e-2));
         mapModuleConfig.setStringProperty("dc-fallback-enabled-after-ac-divergence", Boolean.toString(false));
         mapModuleConfig.setStringProperty("sensitivity-variable-batch-size", Integer.toString(1234));
+        mapModuleConfig.setStringProperty("enable-results-for-paired-half-lines", Boolean.toString(true));
 
         FlowDecompositionParameters parameters = FlowDecompositionParameters.load(platformConfig);
         assertTrue(parameters.isLossesCompensationEnabled());
@@ -75,6 +77,7 @@ class FlowDecompositionParametersTests {
         assertEquals(1e-2, parameters.getProportionalRescalerMinFlowTolerance(), EPSILON);
         assertFalse(parameters.isDcFallbackEnabledAfterAcDivergence());
         assertEquals(1234, parameters.getSensitivityVariableBatchSize());
+        assertTrue(parameters.getEnableResultsForPairedHalfLines());
     }
 
     @Test
@@ -89,5 +92,6 @@ class FlowDecompositionParametersTests {
         assertEquals(FlowDecompositionParameters.RescaleMode.NONE, parameters.getRescaleMode());
         assertEquals(FlowDecompositionParameters.DEFAULT_PROPORTIONAL_RESCALER_MIN_FLOW_TOLERANCE, parameters.getProportionalRescalerMinFlowTolerance(), EPSILON / 100);
         assertTrue(parameters.isDcFallbackEnabledAfterAcDivergence());
+        assertFalse(parameters.getEnableResultsForPairedHalfLines());
     }
 }

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionResultsTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionResultsTests.java
@@ -92,7 +92,7 @@ class FlowDecompositionResultsTests {
         nStateBuilder.savePstFlowMatrix(new SparseMatrixWithIndexesCSC(xnecMap, Map.of(PST_COLUMN_NAME, 0), pstMatrix));
         nStateBuilder.saveAcCurrentTerminal1(Map.of(branchId, 5.0));
         nStateBuilder.saveAcCurrentTerminal2(Map.of(branchId, 5.0));
-        nStateBuilder.build(decomposedFlowRescaler, network);
+        nStateBuilder.build(decomposedFlowRescaler, network, false);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
         assertEquals(1, decomposedFlowMap.size());
@@ -123,7 +123,7 @@ class FlowDecompositionResultsTests {
         n1StateBuilder.savePstFlowMatrix(new SparseMatrixWithIndexesCSC(xnecMap, Map.of(PST_COLUMN_NAME, 0), pstMatrix));
         n1StateBuilder.saveAcCurrentTerminal1(Map.of(branchId, 5.0));
         n1StateBuilder.saveAcCurrentTerminal2(Map.of(branchId, 5.0));
-        n1StateBuilder.build(decomposedFlowRescaler, network);
+        n1StateBuilder.build(decomposedFlowRescaler, network, false);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
         assertEquals(1, decomposedFlowMap.size());
@@ -154,7 +154,7 @@ class FlowDecompositionResultsTests {
         n2StateBuilder.savePstFlowMatrix(new SparseMatrixWithIndexesCSC(xnecMap, Map.of(PST_COLUMN_NAME, 0), pstMatrix));
         n2StateBuilder.saveAcCurrentTerminal1(Map.of(branchId, 5.0));
         n2StateBuilder.saveAcCurrentTerminal2(Map.of(branchId, 5.0));
-        n2StateBuilder.build(decomposedFlowRescaler, network);
+        n2StateBuilder.build(decomposedFlowRescaler, network, false);
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
         assertEquals(1, decomposedFlowMap.size());

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
@@ -209,8 +209,8 @@ public class FlowDecompositionTests {
                 .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)
                 .setLossesCompensationEpsilon(FlowDecompositionParameters.DISABLE_LOSSES_COMPENSATION_EPSILON)
                 .setSensitivityEpsilon(FlowDecompositionParameters.DISABLE_SENSITIVITY_EPSILON)
-                .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE);
-        // TODO setEnableResultsForPairedHalfLines(true)
+                .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE)
+                .setEnableResultsForPairedHalfLines(true);
         // TODO test with MAX_CURRENT_OVERLOAD rescaler
         FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, xnecProvider, flowDecompositionParameters);
         assertEquals(3, flowDecompositionResults.getDecomposedFlowMap().size());

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
@@ -224,9 +224,9 @@ public class FlowDecompositionTests {
                 .setEnableResultsForPairedHalfLines(true);
         FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, xnecProvider, flowDecompositionParameters);
         assertEquals(3, flowDecompositionResults.getDecomposedFlowMap().size());
-        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "", Country.FR, Country.BE, 100.47049345958887, 100.16132637896166, 100.40091974899302, 0.000000, 0.000000, 0.000000, -0.08500982971770546, 0.000000, -0.1545835403136238, 0.000000);
-        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1", "FGEN1 11 X     11 1", "", Country.FR, null, 100.47049345958887, 100.16132637896166, 100.40091974899302, 0.000000, 0.000000, 0.000000, -0.08500982971770546, 0.000000, -0.1545835403136238, 0.000000);
-        validateFlowDecomposition(flowDecompositionResults, "X     11 BLOAD 11 1", "X     11 BLOAD 11 1", "", Country.BE, null, -100.33134603839709, -100.16132637896166, 100.40091974899302, 0.000000, 0.000000, 0.000000, -0.08500982971770546, 0.000000, -0.1545835403136238, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "", Country.FR, Country.BE, 100.47049345958887, 100.20292894355313, 100.43570660424885, 0.000000, 0.000000, 0.000000, -0.11638883038195749, 0.000000, -0.11638883031375974, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1", "FGEN1 11 X     11 1", "", Country.FR, null, 100.47049345958887, 100.20292894355313, 100.43570660424885, 0.000000, 0.000000, 0.000000, -0.11638883038195749, 0.000000, -0.11638883031375974, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "X     11 BLOAD 11 1", "X     11 BLOAD 11 1", "", Country.BE, null, -100.33134603839709, -100.20292894355313, 100.43570660424885, 0.000000, 0.000000, 0.000000, -0.11638883038195749, 0.000000, -0.11638883031375974, 0.000000);
     }
 
     @Test
@@ -246,9 +246,9 @@ public class FlowDecompositionTests {
         FlowDecompositionComputer flowDecompositionComputer = new FlowDecompositionComputer(flowDecompositionParameters, new LoadFlowParameters());
         FlowDecompositionResults flowDecompositionResults = flowDecompositionComputer.run(xnecProvider, network);
         assertEquals(3, flowDecompositionResults.getDecomposedFlowMap().size());
-        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "", Country.FR, Country.BE, 100.47049345958887, 100.16132637896166, 274.61826973991793, 0.000000, 0.000000, 0.000000, -0.23252030366181453, 0.000000, -0.4228194769263953, 0.000000);
-        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1", "FGEN1 11 X     11 1", "", Country.FR, null, 100.47049345958887, 100.16132637896166, 274.61826973991793, 0.000000, 0.000000, 0.000000, -0.23252030366181453, 0.000000, -0.4228194769263953, 0.000000);
-        validateFlowDecomposition(flowDecompositionResults, "X     11 BLOAD 11 1", "X     11 BLOAD 11 1", "", Country.BE, null, -100.33134603839709, -100.16132637896166, 221.16325173395484, 0.000000, 0.000000, 0.000000, -0.18725974240794835, 0.000000, -0.34051678536192725, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "", Country.FR, Country.BE, 100.47049345958887, 100.20292894355313, 274.5993629521137, 0.000000, 0.000000, 0.000000, -0.3182164964852758, 0.000000, -0.3182164962988176, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1", "FGEN1 11 X     11 1", "", Country.FR, null, 100.47049345958887, 100.20292894355313, 274.5993629521137, 0.000000, 0.000000, 0.000000, -0.3182164964852758, 0.000000, -0.3182164962988176, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "X     11 BLOAD 11 1", "X     11 BLOAD 11 1", "", Country.BE, null, -100.33134603839709, -100.20292894355313, 221.1480251917638, 0.000000, 0.000000, 0.000000, -0.25627499286454153, 0.000000, -0.2562749927143778, 0.000000);
     }
 
     @Test

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
@@ -214,7 +214,8 @@ public class FlowDecompositionTests {
         FlowDecompositionResults flowDecompositionResults = runFlowDecomposition(network, xnecProvider, flowDecompositionParameters);
         assertEquals(3, flowDecompositionResults.getDecomposedFlowMap().size());
         validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "", Country.FR, Country.BE, 100.47049345958887, 100.16132637896166, 100.40091974899302, 0.000000, 0.000000, 0.000000, -0.08500982971770546, 0.000000, -0.1545835403136238, 0.000000);
-        // TODO validate other results
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1", "FGEN1 11 X     11 1", "", Country.FR, null, 100.47049345958887, 100.16132637896166, 100.40091974899302, 0.000000, 0.000000, 0.000000, -0.08500982971770546, 0.000000, -0.1545835403136238, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "X     11 BLOAD 11 1", "X     11 BLOAD 11 1", "", Country.BE, null, -100.33134603839709, -100.16132637896166, 100.40091974899302, 0.000000, 0.000000, 0.000000, -0.08500982971770546, 0.000000, -0.1545835403136238, 0.000000);
     }
 
     @Test
@@ -234,6 +235,9 @@ public class FlowDecompositionTests {
         FlowDecompositionComputer flowDecompositionComputer = new FlowDecompositionComputer(flowDecompositionParameters, new LoadFlowParameters());
         FlowDecompositionResults flowDecompositionResults = flowDecompositionComputer.run(xnecProvider, network);
         assertEquals(3, flowDecompositionResults.getDecomposedFlowMap().size());
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "FGEN1 11 X     11 1 + X     11 BLOAD 11 1", "", Country.FR, Country.BE, 100.47049345958887, 100.16132637896166, 274.61826973991793, 0.000000, 0.000000, 0.000000, -0.23252030366181453, 0.000000, -0.4228194769263953, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "FGEN1 11 X     11 1", "FGEN1 11 X     11 1", "", Country.FR, null, 100.47049345958887, 100.16132637896166, 274.61826973991793, 0.000000, 0.000000, 0.000000, -0.23252030366181453, 0.000000, -0.4228194769263953, 0.000000);
+        validateFlowDecomposition(flowDecompositionResults, "X     11 BLOAD 11 1", "X     11 BLOAD 11 1", "", Country.BE, null, -100.33134603839709, -100.16132637896166, 221.16325173395484, 0.000000, 0.000000, 0.000000, -0.18725974240794835, 0.000000, -0.34051678536192725, 0.000000);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
As of today, it is not possible to have flow decomposition results for each half line (paired dangling line) of a tie line.


**What is the new behavior (if this is a feature change)?**
A new flow decomposition parameter (boolean - `enableResultsForPairedHalfLines`) will allow to produce flow decomposition results for these paired half lines.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
