### PR TITLE
Xnec provider with powsybl core contingency

### DIFF
--- a/docs/flow_decomposition/flow-decomposition-inputs.md
+++ b/docs/flow_decomposition/flow-decomposition-inputs.md
@@ -39,3 +39,6 @@ base case. Basic implementations of this interface are available:
 - Set of all interconnections on the network with the addition of all branches that have a maximum zonal PTDF greater than 5%.
 
 Post contingency network elements can only be given to the algorithm using selection by IDs.
+A Contingency can be defined by its ID and the IDs of the affected equipment, which creates a 
+PowSyBl branch contingency by default. Alternatively, it can be specified directly using the 
+PowSyBl Contingency object. 

--- a/docs/flow_decomposition/flow-decomposition-inputs.md
+++ b/docs/flow_decomposition/flow-decomposition-inputs.md
@@ -40,5 +40,5 @@ base case. Basic implementations of this interface are available:
 
 Post contingency network elements can only be given to the algorithm using selection by IDs.
 A Contingency can be defined by its ID and the IDs of the affected equipment, which creates a 
-PowSyBl branch contingency by default. Alternatively, it can be specified directly using the 
-PowSyBl Contingency object. 
+PowSyBl branch contingency by default. Alternatively, it can be specified directly using the
+PowSyBl [Contingency](https://powsybl.readthedocs.io/projects/powsybl-core/en/stable/simulation/security/index.html#contingencies) object. 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/xnec_provider/XnecProviderByIds.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/xnec_provider/XnecProviderByIds.java
@@ -60,8 +60,12 @@ public final class XnecProviderByIds implements XnecProvider {
 
         public Builder addContingency(String contingencyId, Set<String> contingencyElementIdSet) {
             Contingency contingency = createContingency(contingencyId, contingencyElementIdSet);
-            contingencyIdToContingencyMap.put(contingencyId, contingency);
-            contingencyToXnecMap.put(contingency, new HashSet<>());
+            return addContingency(contingency);
+        }
+
+        public Builder addContingency(Contingency contingency) {
+            this.contingencyIdToContingencyMap.put(contingency.getId(), contingency);
+            this.contingencyToXnecMap.put(contingency, new HashSet<>());
             return this;
         }
 

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionWithContingencyTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionWithContingencyTests.java
@@ -120,6 +120,30 @@ class FlowDecompositionWithContingencyTests {
     }
 
     @Test
+    void testSingleN1PostDanglinLineContingencyState() {
+        String networkFileName = "19700101_0000_FO4_UX1.uct";
+        String branchId = "DB000011 DF000011 1";
+        String contingencyId = "XBF00011 FB000011 1";
+        String xnecId = "DB000011 DF000011 1_XBF00011 FB000011 1";
+
+        Network network = TestUtils.importNetwork(networkFileName);
+        Contingency contingency = Contingency.builder(contingencyId).addDanglingLine(contingencyId).build();
+        XnecProvider xnecProvider = XnecProviderByIds.builder()
+                .addContingency(contingency)
+                .addNetworkElementsAfterContingencies(Set.of(branchId), Set.of(contingencyId))
+                .build();
+        FlowDecompositionParameters flowDecompositionParameters = FlowDecompositionParameters.load()
+                .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)
+                .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE);
+        FlowDecompositionComputer flowComputer = new FlowDecompositionComputer(flowDecompositionParameters);
+        FlowDecompositionResults flowDecompositionResults = flowComputer.run(xnecProvider, network);
+        TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.getRescaleMode(), flowDecompositionResults);
+
+        Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
+        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -545.584, 32.623);
+    }
+
+    @Test
     void testNStateAndN1PostContingencyState() {
         String networkFileName = "19700101_0000_FO4_UX1.uct";
         String branchId = "DB000011 DF000011 1";

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionWithContingencyTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionWithContingencyTests.java
@@ -7,6 +7,7 @@
  */
 package com.powsybl.flow_decomposition;
 
+import com.powsybl.contingency.Contingency;
 import com.powsybl.flow_decomposition.xnec_provider.XnecProviderByIds;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
@@ -44,6 +45,78 @@ class FlowDecompositionWithContingencyTests {
 
         Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
         validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -1269.932, 31.943);
+    }
+
+    @Test
+    void testSingleN1PostBranchContingencyState() {
+        String networkFileName = "19700101_0000_FO4_UX1.uct";
+        String branchId = "DB000011 DF000011 1";
+        String contingencyId = "DD000011 DF000011 1";
+        String xnecId = "DB000011 DF000011 1_DD000011 DF000011 1";
+
+        Network network = TestUtils.importNetwork(networkFileName);
+        Contingency contingency = Contingency.builder(contingencyId).addBranch(contingencyId).build();
+        XnecProvider xnecProvider = XnecProviderByIds.builder()
+                .addContingency(contingency)
+                .addNetworkElementsAfterContingencies(Set.of(branchId), Set.of(contingencyId))
+                .build();
+        FlowDecompositionParameters flowDecompositionParameters = FlowDecompositionParameters.load()
+                .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)
+                .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE);
+        FlowDecompositionComputer flowComputer = new FlowDecompositionComputer(flowDecompositionParameters);
+        FlowDecompositionResults flowDecompositionResults = flowComputer.run(xnecProvider, network);
+        TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.getRescaleMode(), flowDecompositionResults);
+
+        Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
+        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -1269.932, 31.943);
+    }
+
+    @Test
+    void testSingleN1PostLoadContingencyState() {
+        String networkFileName = "19700101_0000_FO4_UX1.uct";
+        String branchId = "DB000011 DF000011 1";
+        String contingencyId = "FD000011_load";
+        String xnecId = "DB000011 DF000011 1_FD000011_load";
+
+        Network network = TestUtils.importNetwork(networkFileName);
+        Contingency contingency = Contingency.builder(contingencyId).addLoad(contingencyId).build();
+        XnecProvider xnecProvider = XnecProviderByIds.builder()
+                .addContingency(contingency)
+                .addNetworkElementsAfterContingencies(Set.of(branchId), Set.of(contingencyId))
+                .build();
+        FlowDecompositionParameters flowDecompositionParameters = FlowDecompositionParameters.load()
+                .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)
+                .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE);
+        FlowDecompositionComputer flowComputer = new FlowDecompositionComputer(flowDecompositionParameters);
+        FlowDecompositionResults flowDecompositionResults = flowComputer.run(xnecProvider, network);
+        TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.getRescaleMode(), flowDecompositionResults);
+
+        Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
+        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -312.215, 29.285);
+    }
+
+    @Test
+    void testSingleN1PostSwitchContingencyState() {
+        String networkFileName = "19700101_0000_FO4_UX1.uct";
+        String branchId = "DB000011 DF000011 1";
+        String contingencyId = "FB000021 FB000022 1";
+        String xnecId = "DB000011 DF000011 1_FB000021 FB000022 1";
+
+        Network network = TestUtils.importNetwork(networkFileName);
+        Contingency contingency = Contingency.builder(contingencyId).addSwitch(contingencyId).build();
+        XnecProvider xnecProvider = XnecProviderByIds.builder()
+                .addContingency(contingency)
+                .addNetworkElementsAfterContingencies(Set.of(branchId), Set.of(contingencyId))
+                .build();
+        FlowDecompositionParameters flowDecompositionParameters = FlowDecompositionParameters.load()
+                .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)
+                .setRescaleMode(FlowDecompositionParameters.RescaleMode.NONE);
+        FlowDecompositionComputer flowComputer = new FlowDecompositionComputer(flowDecompositionParameters);
+        FlowDecompositionResults flowDecompositionResults = flowComputer.run(xnecProvider, network);
+        TestUtils.assertCoherenceTotalFlow(flowDecompositionParameters.getRescaleMode(), flowDecompositionResults);
+
+        Map<String, DecomposedFlow> decomposedFlowMap = flowDecompositionResults.getDecomposedFlowMap();
+        validateFlowDecompositionOnXnec(xnecId, branchId, contingencyId, decomposedFlowMap.get(xnecId), -300.186, 22.162);
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This PR adds support for creating XnecProvider with native PowSyBl Contingency types, enabling the flow decomposition module to run with the PowSyBl Contingency types. Previously, only the Branch Contingency type was supported. Unit tests and a minor documentation update are included.

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently, an XnecProvider object can only be created using PowSyBl Branch Contingency. If IDs of network components other than branches are provided, an error occurs during flow decomposition when applying the contingency. As a result, flow decomposition cannot be performed with all PowSyBl Contingency types.

**What is the new behavior (if this is a feature change)?**
The proposed changes allow an XnecProvider object to be created by directly adding PowSyBl Contingency object. This enables flow decomposition to be performed with all PowSyBl Contingency types.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No
