### PR TITLE
Remove deprecated isOk() for LF results, force connected component to main

### DIFF
--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -62,9 +62,9 @@ public interface FlowDecompositionObserver {
     /**
      * Called when the PTDF matrix is computed (for base case or contingency)
      *
-     * @param pdtfMatrix the matrix of ptdf indexed by (line, node)
+     * @param ptdfMatrix the matrix of ptdf indexed by (line, node)
      */
-    void computedPtdfMatrix(Map<String, Map<String, Double>> pdtfMatrix);
+    void computedPtdfMatrix(Map<String, Map<String, Double>> ptdfMatrix);
 
     /**
      * Called when the PSDF matrix is computed (for base case or contingency)

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/LoadFlowRunningService.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/LoadFlowRunningService.java
@@ -32,13 +32,13 @@ class LoadFlowRunningService {
     Result runAcLoadflow(Network network, LoadFlowParameters loadFlowParameters, boolean isDcFallbackEnabledAfterAcDivergence) {
         LoadFlowParameters acEnforcedParameters = enforceAcLoadFlowCalculation(loadFlowParameters);
         LoadFlowResult acLoadFlowResult = runner.run(network, acEnforcedParameters);
-        if (!acLoadFlowResult.isOk() && isDcFallbackEnabledAfterAcDivergence) {
+        if (!acLoadFlowResult.isFullyConverged() && isDcFallbackEnabledAfterAcDivergence) {
             LOGGER.warn("AC loadflow divergence. Running DC loadflow as fallback procedure.");
             return runDcLoadflow(network, loadFlowParameters)
                 .setFallbackHasBeenActivated(FALLBACK_HAS_BEEN_ACTIVATED);
         }
-        if (!acLoadFlowResult.isOk()) {
-            throw new PowsyblException("AC loadfow divergence without fallback procedure enabled.");
+        if (!acLoadFlowResult.isFullyConverged()) {
+            throw new PowsyblException("AC loadflow divergence without fallback procedure enabled.");
         }
         return new Result(acLoadFlowResult, FALLBACK_HAS_NOT_BEEN_ACTIVATED);
     }
@@ -46,8 +46,8 @@ class LoadFlowRunningService {
     Result runDcLoadflow(Network network, LoadFlowParameters loadFlowParameters) {
         LoadFlowParameters dcEnforcedParameters = enforceDcLoadFlowCalculation(loadFlowParameters);
         LoadFlowResult dcLoadFlowResult = runner.run(network, dcEnforcedParameters);
-        if (!dcLoadFlowResult.isOk()) {
-            throw new PowsyblException("DC loadfow divergence.");
+        if (!dcLoadFlowResult.isFullyConverged()) {
+            throw new PowsyblException("DC loadflow divergence.");
         }
         return new Result(dcLoadFlowResult, FALLBACK_HAS_NOT_BEEN_ACTIVATED);
     }

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
@@ -120,9 +120,9 @@ class FlowDecompositionObserverTest {
         }
 
         @Override
-        public void computedPtdfMatrix(Map<String, Map<String, Double>> pdtfMatrix) {
+        public void computedPtdfMatrix(Map<String, Map<String, Double>> ptdfMatrix) {
             addEvent(Event.COMPUTED_PTDF_MATRIX);
-            this.ptdfs.put(currentContingency, pdtfMatrix);
+            this.ptdfs.put(currentContingency, ptdfMatrix);
         }
 
         @Override

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionTests.java
@@ -196,6 +196,16 @@ public class FlowDecompositionTests {
         assertTrue(flowDecompositionResults.getZoneSet().contains(Country.NL));
     }
 
+    @Test
+    void testConnectedComponentModeChangesFromAllToMain() {
+        LoadFlowParameters loadFlowParameters = new LoadFlowParameters().setConnectedComponentMode(LoadFlowParameters.ConnectedComponentMode.ALL);
+        FlowDecompositionComputer flowDecompositionComputer = new FlowDecompositionComputer(new FlowDecompositionParameters(), loadFlowParameters);
+        // lfParameters inside flow decomposition changed from all to main
+        assertEquals(FlowDecompositionComputer.MAIN_CONNECTED_COMPONENT, flowDecompositionComputer.getLoadFlowParameters().getConnectedComponentMode());
+        // original lfParameters didn't change
+        assertEquals(LoadFlowParameters.ConnectedComponentMode.ALL, loadFlowParameters.getConnectedComponentMode());
+    }
+
     private static FlowDecompositionResults runFlowDecomposition(Network network, XnecProvider xnecProvider) {
         FlowDecompositionParameters flowDecompositionParameters = new FlowDecompositionParameters()
             .setEnableLossesCompensation(FlowDecompositionParameters.ENABLE_LOSSES_COMPENSATION)

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/LoadFlowFallbackTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/LoadFlowFallbackTests.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class LoadFlowFallbackTests {
 
-    public static final String FALLBACK_MESSAGE = "AC loadfow divergence without fallback procedure enabled";
+    public static final String FALLBACK_MESSAGE = "AC loadflow divergence without fallback procedure enabled.";
 
     @Test
     void testIntegrationOfDisabledFallbackOnNetworkThatDoesNotConvergeInAc() {
@@ -38,7 +38,7 @@ class LoadFlowFallbackTests {
         XnecProvider xnecProvider = XnecProviderByIds.builder().addNetworkElementsOnBasecase(Set.of("UNUSED")).build();
         Executable flowComputerExecutable = () -> flowComputer.run(xnecProvider, network);
         Exception exception = assertThrows(PowsyblException.class, flowComputerExecutable, FALLBACK_MESSAGE);
-        assertEquals("AC loadfow divergence without fallback procedure enabled.", exception.getMessage());
+        assertEquals(FALLBACK_MESSAGE, exception.getMessage());
     }
 
     @Test
@@ -48,7 +48,7 @@ class LoadFlowFallbackTests {
         LoadFlowRunningService loadFlowRunningService = new LoadFlowRunningService(LoadFlow.find());
         LoadFlowRunningService.Result loadFlowResult = loadFlowRunningService.runAcLoadflow(
             network, new LoadFlowParameters(), LoadFlowRunningService.FALLBACK_HAS_BEEN_ACTIVATED);
-        assertTrue(loadFlowResult.getLoadFlowResult().isOk());
+        assertTrue(loadFlowResult.getLoadFlowResult().isFullyConverged());
         assertFalse(loadFlowResult.fallbackHasBeenActivated());
     }
 
@@ -59,7 +59,7 @@ class LoadFlowFallbackTests {
         LoadFlowRunningService loadFlowRunningService = new LoadFlowRunningService(LoadFlow.find());
         LoadFlowRunningService.Result loadFlowResult = loadFlowRunningService.runAcLoadflow(
             network, new LoadFlowParameters(), LoadFlowRunningService.FALLBACK_HAS_NOT_BEEN_ACTIVATED);
-        assertTrue(loadFlowResult.getLoadFlowResult().isOk());
+        assertTrue(loadFlowResult.getLoadFlowResult().isFullyConverged());
         assertFalse(loadFlowResult.fallbackHasBeenActivated());
     }
 
@@ -70,7 +70,7 @@ class LoadFlowFallbackTests {
         LoadFlowRunningService loadFlowRunningService = new LoadFlowRunningService(LoadFlow.find());
         LoadFlowRunningService.Result loadFlowResult = loadFlowRunningService.runAcLoadflow(
             network, new LoadFlowParameters(), LoadFlowRunningService.FALLBACK_HAS_BEEN_ACTIVATED);
-        assertTrue(loadFlowResult.getLoadFlowResult().isOk());
+        assertTrue(loadFlowResult.getLoadFlowResult().isFullyConverged());
         assertTrue(loadFlowResult.fallbackHasBeenActivated());
     }
 
@@ -82,6 +82,6 @@ class LoadFlowFallbackTests {
         Executable loadFlowRunningServiceExecutable = () -> loadFlowRunningService.runAcLoadflow(
             network, new LoadFlowParameters(), LoadFlowRunningService.FALLBACK_HAS_NOT_BEEN_ACTIVATED);
         Exception exception = assertThrows(PowsyblException.class, loadFlowRunningServiceExecutable, FALLBACK_MESSAGE);
-        assertEquals("AC loadfow divergence without fallback procedure enabled.", exception.getMessage());
+        assertEquals(FALLBACK_MESSAGE, exception.getMessage());
     }
 }

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NodalInjectionTests.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/NodalInjectionTests.java
@@ -94,7 +94,7 @@ class NodalInjectionTests {
     private static Map<String, Map<String, Double>> getNodalInjections(String networkFileName) {
         Network network = importNetwork(networkFileName);
         LoadFlowResult loadFlowResult = LoadFlow.run(network);
-        if (!loadFlowResult.isOk()) {
+        if (!loadFlowResult.isFullyConverged()) {
             LoadFlow.run(network, LoadFlowParameters.load().setDc(true));
         }
         AutoGlskProvider glskProvider = new AutoGlskProvider();
@@ -111,7 +111,7 @@ class NodalInjectionTests {
     private static Map<String, Double> getReferenceNodalInjections(String networkFileName) {
         Network network = importNetwork(networkFileName);
         LoadFlowResult loadFlowResult = LoadFlow.run(network);
-        if (!loadFlowResult.isOk()) {
+        if (!loadFlowResult.isFullyConverged()) {
             LoadFlow.run(network, LoadFlowParameters.load().setDc(true));
         }
         List<Branch> xnecList = network.getBranchStream().collect(Collectors.toList());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
[This PR](https://github.com/powsybl/powsybl-open-loadflow/pull/1075) in OLF revealed that there are cases in the flow decomposition where the fallback is not activated as it should.

The `loadFlowResult.isOk()` method being deprecated, it doesn't reflect the case where the main island has diverged and all the other islands have not.

The aforementioned PR in OLF stopped updating terminals in case of a divergence, which trigger the exception in `ReferenceNodalInjectionComputer` (NaN value of a terminal).


**What is the new behavior (if this is a feature change)?**
- Loadflow for flow decomposition is only launched on the main island
- Remove methods `isOk()` for LoadFlowResult and use the updated version `isFullyConverged()`


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No