### PR TITLE
Flow decomposition observers refactoring

### DIFF
--- a/docs/flow_decomposition/flow-decomposition-detailed-results.md
+++ b/docs/flow_decomposition/flow-decomposition-detailed-results.md
@@ -10,8 +10,6 @@ Observers are notified of the following events:
 * when the nodal injection matrix is computed (for base case or contingency)
 * when the PTDF matrix is computed (for base case or contingency)
 * when the PSDF matrix is computed (for base case or contingency)
-* when the AC nodal injections matrix is computed (for base case or contingency)
-* when the DC nodal injections matrix is computed (for base case or contingency)
 * when the AC loadflow is computed (for base case or contingency)
 * when the DC loadflow is computed (for base case or contingency)
 * when the computation is done

--- a/docs/flow_decomposition/flow-decomposition-detailed-results.md
+++ b/docs/flow_decomposition/flow-decomposition-detailed-results.md
@@ -14,6 +14,9 @@ Observers are notified of the following events:
 * when the DC loadflow is computed (for base case or contingency)
 * when the computation is done
 
+After AC and DC loadflows the observer has access to the network at that stage, as well as the loadflow result.
+In this manner, it is possible to retrieve any information of the network after loadflow calculations.
+
 Note that these observers are meant to be used for testing purposes only.
 Using observers impacts calculation performance and therefore are not suitable in production environment.
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowComputerUtils.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowComputerUtils.java
@@ -27,11 +27,8 @@ public final class FlowComputerUtils {
         // empty constructor
     }
 
-    public static Map<String, Double> calculateAcTerminalReferenceFlows(Collection<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult, TwoSides side) {
-        if (loadFlowServiceAcResult.fallbackHasBeenActivated()) {
-            return xnecList.stream().collect(Collectors.toMap(Identifiable::getId, branch -> Double.NaN));
-        }
-        return getTerminalReferenceFlow(xnecList, side);
+    public static Map<String, Double> calculateAcTerminalReferenceFlows(Collection<Branch> xnecList, boolean fallbackHasBeenActivated, TwoSides side) {
+        return fallbackHasBeenActivated ? getFallbackActivatedTerminalResults(xnecList) : getTerminalReferenceFlow(xnecList, side);
     }
 
     public static Map<String, Double> getTerminalReferenceFlow(Collection<Branch> xnecList, TwoSides side) {
@@ -42,11 +39,8 @@ public final class FlowComputerUtils {
                 ));
     }
 
-    public static Map<String, Double> calculateAcTerminalCurrents(Collection<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult, TwoSides side) {
-        if (loadFlowServiceAcResult.fallbackHasBeenActivated()) {
-            return xnecList.stream().collect(Collectors.toMap(Identifiable::getId, branch -> Double.NaN));
-        }
-        return getTerminalCurrent(xnecList, side);
+    public static Map<String, Double> calculateAcTerminalCurrents(Collection<Branch> xnecList, boolean fallbackHasBeenActivated, TwoSides side) {
+        return fallbackHasBeenActivated ? getFallbackActivatedTerminalResults(xnecList) : getTerminalCurrent(xnecList, side);
     }
 
     public static Map<String, Double> getTerminalCurrent(Collection<Branch> xnecList, TwoSides side) {
@@ -55,5 +49,9 @@ public final class FlowComputerUtils {
                         Identifiable::getId,
                         branch -> branch.getTerminal(side).getI()
                 ));
+    }
+
+    private static Map<String, Double> getFallbackActivatedTerminalResults(Collection<Branch> xnecList) {
+        return xnecList.stream().collect(Collectors.toMap(Identifiable::getId, branch -> Double.NaN));
     }
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -149,14 +149,14 @@ public class FlowDecompositionComputer {
                                        Map<Country, Map<String, Double>> glsks,
                                        LoadFlowRunningService.Result loadFlowServiceAcResult) {
         // AC load flow
-        saveAcLoadFlowResults(flowDecompositionResultsBuilder, network, xnecList, loadFlowServiceAcResult.fallbackHasBeenActivated());
+        saveAcLoadFlowResults(flowDecompositionResultsBuilder, network, xnecList, loadFlowServiceAcResult);
 
         // Losses compensation
         compensateLosses(network);
 
         // DC load flow
         runDcLoadFlow(network);
-        saveDcLoadFlowResults(flowDecompositionResultsBuilder, network, xnecList);
+        saveDcLoadFlowResults(flowDecompositionResultsBuilder, network, xnecList, loadFlowServiceAcResult);
 
         // Nodal injections
         NetworkMatrixIndexes networkMatrixIndexes = new NetworkMatrixIndexes(network, new ArrayList<>(xnecList));
@@ -187,10 +187,10 @@ public class FlowDecompositionComputer {
         return loadFlowRunningService.runAcLoadflow(network, loadFlowParameters, parameters.isDcFallbackEnabledAfterAcDivergence());
     }
 
-    private void saveAcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultsBuilder, Network network, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
-        saveAcReferenceFlows(flowDecompositionResultsBuilder, xnecList, fallbackHasBeenActivated);
-        saveAcCurrents(flowDecompositionResultsBuilder, xnecList, fallbackHasBeenActivated);
-        observers.computedAcLoadFlowResults(network, fallbackHasBeenActivated);
+    private void saveAcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultsBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
+        saveAcReferenceFlows(flowDecompositionResultsBuilder, xnecList, loadFlowServiceAcResult.fallbackHasBeenActivated());
+        saveAcCurrents(flowDecompositionResultsBuilder, xnecList, loadFlowServiceAcResult.fallbackHasBeenActivated());
+        observers.computedAcLoadFlowResults(network, loadFlowServiceAcResult);
     }
 
     private void saveAcReferenceFlows(FlowDecompositionResults.PerStateBuilder flowDecompositionResultsBuilder, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
@@ -242,9 +242,9 @@ public class FlowDecompositionComputer {
         return nodalInjectionsMatrix;
     }
 
-    private void saveDcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList) {
+    private void saveDcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
         flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlow(xnecList, TwoSides.ONE));
-        observers.computedDcLoadFlowResults(network);
+        observers.computedDcLoadFlowResults(network, loadFlowServiceAcResult);
     }
 
     private SensitivityAnalyser getSensitivityAnalyser(Network network, NetworkMatrixIndexes networkMatrixIndexes) {

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -188,19 +188,19 @@ public class FlowDecompositionComputer {
     }
 
     private void saveAcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultsBuilder, Network network, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
-        saveAcReferenceFlows(flowDecompositionResultsBuilder, network, xnecList, fallbackHasBeenActivated);
-        saveAcCurrents(flowDecompositionResultsBuilder, network, xnecList, fallbackHasBeenActivated);
+        saveAcReferenceFlows(flowDecompositionResultsBuilder, xnecList, fallbackHasBeenActivated);
+        saveAcCurrents(flowDecompositionResultsBuilder, xnecList, fallbackHasBeenActivated);
         observers.computedAcLoadFlowResults(network, fallbackHasBeenActivated);
     }
 
-    private void saveAcReferenceFlows(FlowDecompositionResults.PerStateBuilder flowDecompositionResultsBuilder, Network network, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
+    private void saveAcReferenceFlows(FlowDecompositionResults.PerStateBuilder flowDecompositionResultsBuilder, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
         Map<String, Double> acTerminal1ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, fallbackHasBeenActivated, TwoSides.ONE);
         Map<String, Double> acTerminal2ReferenceFlows = FlowComputerUtils.calculateAcTerminalReferenceFlows(xnecList, fallbackHasBeenActivated, TwoSides.TWO);
         flowDecompositionResultsBuilder.saveAcTerminal1ReferenceFlow(acTerminal1ReferenceFlows);
         flowDecompositionResultsBuilder.saveAcTerminal2ReferenceFlow(acTerminal2ReferenceFlows);
     }
 
-    private void saveAcCurrents(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
+    private void saveAcCurrents(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Set<Branch> xnecList, boolean fallbackHasBeenActivated) {
         Map<String, Double> acTerminal1Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, fallbackHasBeenActivated, TwoSides.ONE);
         Map<String, Double> acTerminal2Currents = FlowComputerUtils.calculateAcTerminalCurrents(xnecList, fallbackHasBeenActivated, TwoSides.TWO);
         flowDecompositionResultBuilder.saveAcCurrentTerminal1(acTerminal1Currents);

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -155,8 +155,8 @@ public class FlowDecompositionComputer {
         compensateLosses(network);
 
         // DC load flow
-        runDcLoadFlow(network);
-        saveDcLoadFlowResults(flowDecompositionResultsBuilder, network, xnecList, loadFlowServiceAcResult);
+        LoadFlowRunningService.Result loadFlowServiceDcResult = runDcLoadFlow(network);
+        saveDcLoadFlowResults(flowDecompositionResultsBuilder, network, xnecList, loadFlowServiceDcResult);
 
         // Nodal injections
         NetworkMatrixIndexes networkMatrixIndexes = new NetworkMatrixIndexes(network, new ArrayList<>(xnecList));
@@ -242,9 +242,9 @@ public class FlowDecompositionComputer {
         return nodalInjectionsMatrix;
     }
 
-    private void saveDcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceAcResult) {
+    private void saveDcLoadFlowResults(FlowDecompositionResults.PerStateBuilder flowDecompositionResultBuilder, Network network, Set<Branch> xnecList, LoadFlowRunningService.Result loadFlowServiceDcResult) {
         flowDecompositionResultBuilder.saveDcReferenceFlow(FlowComputerUtils.getTerminalReferenceFlow(xnecList, TwoSides.ONE));
-        observers.computedDcLoadFlowResults(network, loadFlowServiceAcResult);
+        observers.computedDcLoadFlowResults(network, loadFlowServiceDcResult);
     }
 
     private SensitivityAnalyser getSensitivityAnalyser(Network network, NetworkMatrixIndexes networkMatrixIndexes) {

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -9,6 +9,7 @@ package com.powsybl.flow_decomposition;
 
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.loadflow.LoadFlowResult;
 
 import java.util.Map;
 
@@ -82,7 +83,7 @@ public interface FlowDecompositionObserver {
      * @param loadFlowResult loadflow result after AC loadflow
      * @param fallbackHasBeenActivated true if AC loadflow didn't converge
      */
-    void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult, boolean fallbackHasBeenActivated);
+    void computedAcLoadFlowResults(Network network, LoadFlowResult loadFlowResult, boolean fallbackHasBeenActivated);
 
     /**
      * Called after a DC loadflow has been computed
@@ -90,5 +91,5 @@ public interface FlowDecompositionObserver {
      * @param network the network after DC loadflow
      * @param loadFlowResult loadflow result after DC loadflow
      */
-    void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult);
+    void computedDcLoadFlowResults(Network network, LoadFlowResult loadFlowResult);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -76,17 +76,19 @@ public interface FlowDecompositionObserver {
     void computedPsdfMatrix(Map<String, Map<String, Double>> psdfMatrix);
 
     /**
-     * Called after an AC loadflow is launched and terminated
+     * Called after an AC loadflow has been computed
      *
      * @param network the network after AC loadflow
+     * @param loadFlowResult loadflow result after AC loadflow
      * @param fallbackHasBeenActivated true if AC loadflow didn't converge
      */
-    void computedAcLoadFlowResults(Network network, boolean fallbackHasBeenActivated);
+    void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult, boolean fallbackHasBeenActivated);
 
     /**
-     * Called after a DC loadflow is launched and terminated
+     * Called after a DC loadflow has been computed
      *
      * @param network the network after DC loadflow
+     * @param loadFlowResult loadflow result after DC loadflow
      */
-    void computedDcLoadFlowResults(Network network);
+    void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -8,11 +8,13 @@
 package com.powsybl.flow_decomposition;
 
 import com.powsybl.iidm.network.Country;
+import com.powsybl.iidm.network.Network;
 
 import java.util.Map;
 
 /**
  * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
 public interface FlowDecompositionObserver {
 
@@ -74,52 +76,17 @@ public interface FlowDecompositionObserver {
     void computedPsdfMatrix(Map<String, Map<String, Double>> psdfMatrix);
 
     /**
-     * Called when the AC nodal injections matrix is computed (for base case or contingency)
+     * Called after an AC loadflow is launched and terminated
      *
-     * @param positions the positions after AC loadflow
+     * @param network the network after AC loadflow
      * @param fallbackHasBeenActivated true if AC loadflow didn't converge
      */
-    void computedAcNodalInjections(Map<String, Double> positions, boolean fallbackHasBeenActivated);
+    void computedAcLoadFlowResults(Network network, boolean fallbackHasBeenActivated);
 
     /**
-     * Called when the DC nodal injections matrix is computed (for base case or contingency)
+     * Called after a DC loadflow is launched and terminated
      *
-     * @param positions the positions after DC loadflow
+     * @param network the network after DC loadflow
      */
-    void computedDcNodalInjections(Map<String, Double> positions);
-
-    /**
-     * Called when the AC loadflow is computed (for base case or contingency)
-     *
-     * @param flows the terminal 1 flow for all branches
-     */
-    void computedAcFlowsTerminal1(Map<String, Double> flows);
-
-    /**
-     * Called when the AC loadflow is computed (for base case or contingency)
-     *
-     * @param flows the terminal 2 flow for all branches
-     */
-    void computedAcFlowsTerminal2(Map<String, Double> flows);
-
-    /**
-     * Called when the DC loadflow is computed (for base case or contingency)
-     *
-     * @param flows the flows for all branches
-     */
-    void computedDcFlows(Map<String, Double> flows);
-
-    /**
-     * Called when the AC loadflow is computed (for base case or contingency)
-     *
-     * @param currents the terminal 1 current for all branches
-     */
-    void computedAcCurrentsTerminal1(Map<String, Double> currents);
-
-    /**
-     * Called when the AC loadflow is computed (for base case or contingency)
-     *
-     * @param currents the terminal 1 current for all branches
-     */
-    void computedAcCurrentsTerminal2(Map<String, Double> currents);
+    void computedDcLoadFlowResults(Network network);
 }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -82,23 +82,23 @@ public class FlowDecompositionObserverList {
         sendMatrix(FlowDecompositionObserver::computedPsdfMatrix, matrix);
     }
 
-    public void computedAcLoadFlowResults(Network network, boolean isFallBackActivated) {
+    public void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceAcResult) {
         if (observers.isEmpty()) {
             return;
         }
 
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcLoadFlowResults(network, isFallBackActivated);
+            o.computedAcLoadFlowResults(network, loadFlowServiceAcResult, loadFlowServiceAcResult.fallbackHasBeenActivated());
         }
     }
 
-    public void computedDcLoadFlowResults(Network network) {
+    public void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceAcResult) {
         if (observers.isEmpty()) {
             return;
         }
 
         for (FlowDecompositionObserver o : observers) {
-            o.computedDcLoadFlowResults(network);
+            o.computedDcLoadFlowResults(network, loadFlowServiceAcResult);
         }
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -84,13 +84,13 @@ public class FlowDecompositionObserverList {
 
     public void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceAcResult) {
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcLoadFlowResults(network, loadFlowServiceAcResult, loadFlowServiceAcResult.fallbackHasBeenActivated());
+            o.computedAcLoadFlowResults(network, loadFlowServiceAcResult.getLoadFlowResult(), loadFlowServiceAcResult.fallbackHasBeenActivated());
         }
     }
 
-    public void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceAcResult) {
+    public void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceDcResult) {
         for (FlowDecompositionObserver o : observers) {
-            o.computedDcLoadFlowResults(network, loadFlowServiceAcResult);
+            o.computedDcLoadFlowResults(network, loadFlowServiceDcResult.getLoadFlowResult());
         }
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -83,20 +83,12 @@ public class FlowDecompositionObserverList {
     }
 
     public void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        if (observers.isEmpty()) {
-            return;
-        }
-
         for (FlowDecompositionObserver o : observers) {
             o.computedAcLoadFlowResults(network, loadFlowServiceAcResult, loadFlowServiceAcResult.fallbackHasBeenActivated());
         }
     }
 
     public void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowServiceAcResult) {
-        if (observers.isEmpty()) {
-            return;
-        }
-
         for (FlowDecompositionObserver o : observers) {
             o.computedDcLoadFlowResults(network, loadFlowServiceAcResult);
         }

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -7,10 +7,8 @@
  */
 package com.powsybl.flow_decomposition;
 
-import com.powsybl.flow_decomposition.LoadFlowRunningService.Result;
 import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.TwoSides;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +16,7 @@ import java.util.Map;
 
 /**
  * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
+ * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
 public class FlowDecompositionObserverList {
 
@@ -83,59 +82,23 @@ public class FlowDecompositionObserverList {
         sendMatrix(FlowDecompositionObserver::computedPsdfMatrix, matrix);
     }
 
-    public void computedAcFlows(Network network, Result loadFlowServiceAcResult) {
+    public void computedAcLoadFlowResults(Network network, boolean isFallBackActivated) {
         if (observers.isEmpty()) {
             return;
         }
 
         for (FlowDecompositionObserver o : observers) {
-            o.computedAcFlowsTerminal1(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.ONE));
-            o.computedAcFlowsTerminal2(FlowComputerUtils.calculateAcTerminalReferenceFlows(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.TWO));
+            o.computedAcLoadFlowResults(network, isFallBackActivated);
         }
     }
 
-    public void computedDcFlows(Network network) {
+    public void computedDcLoadFlowResults(Network network) {
         if (observers.isEmpty()) {
             return;
         }
 
         for (FlowDecompositionObserver o : observers) {
-            o.computedDcFlows(FlowComputerUtils.getTerminalReferenceFlow(network.getBranchStream().toList(), TwoSides.ONE));
-        }
-    }
-
-    public void computedAcCurrents(Network network, Result loadFlowServiceAcResult) {
-        if (observers.isEmpty()) {
-            return;
-        }
-
-        for (FlowDecompositionObserver o : observers) {
-            o.computedAcCurrentsTerminal1(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.ONE));
-            o.computedAcCurrentsTerminal2(FlowComputerUtils.calculateAcTerminalCurrents(network.getBranchStream().toList(), loadFlowServiceAcResult, TwoSides.TWO));
-        }
-    }
-
-    public void computedAcNodalInjections(Network network, boolean fallbackHasBeenActivated) {
-        if (observers.isEmpty()) {
-            return;
-        }
-
-        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
-
-        for (FlowDecompositionObserver o : observers) {
-            o.computedAcNodalInjections(results, fallbackHasBeenActivated);
-        }
-    }
-
-    public void computedDcNodalInjections(Network network) {
-        if (observers.isEmpty()) {
-            return;
-        }
-
-        Map<String, Double> results = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
-
-        for (FlowDecompositionObserver o : observers) {
-            o.computedDcNodalInjections(results);
+            o.computedDcLoadFlowResults(network);
         }
     }
 

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
@@ -150,14 +150,14 @@ class FlowDecompositionObserverTest {
 
         private void computedAcNodalInjections(Network network) {
             addEvent(Event.COMPUTED_AC_NODAL_INJECTIONS);
-            Map<String, Double> nodalInjections = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
-            this.acNodalInjections.put(currentContingency, nodalInjections);
+            Map<String, Double> injections = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
+            this.acNodalInjections.put(currentContingency, injections);
         }
 
         private void computedDcNodalInjections(Network network) {
             addEvent(Event.COMPUTED_DC_NODAL_INJECTIONS);
-            Map<String, Double> nodalInjections = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
-            this.dcNodalInjections.put(currentContingency, nodalInjections);
+            Map<String, Double> injections = new ReferenceNodalInjectionComputer().run(NetworkUtil.getNodeList(network));
+            this.dcNodalInjections.put(currentContingency, injections);
         }
 
         private void computedAcFlowsTerminal1(Network network, boolean fallbackHasBeenActivated) {

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
@@ -134,7 +134,7 @@ class FlowDecompositionObserverTest {
         }
 
         @Override
-        public void computedAcLoadFlowResults(Network network, boolean fallbackHasBeenActivated) {
+        public void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult, boolean fallbackHasBeenActivated) {
             computedAcNodalInjections(network);
             computedAcFlowsTerminal1(network, fallbackHasBeenActivated);
             computedAcFlowsTerminal2(network, fallbackHasBeenActivated);
@@ -143,7 +143,7 @@ class FlowDecompositionObserverTest {
         }
 
         @Override
-        public void computedDcLoadFlowResults(Network network) {
+        public void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult) {
             computedDcNodalInjections(network);
             computedDcFlows(network);
         }

--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/FlowDecompositionObserverTest.java
@@ -14,6 +14,7 @@ import com.powsybl.iidm.network.Country;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.loadflow.LoadFlowParameters;
+import com.powsybl.loadflow.LoadFlowResult;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
@@ -58,9 +59,9 @@ class FlowDecompositionObserverTest {
         private final ContingencyValue<List<Event>> eventsPerContingency = new ContingencyValue<>();
         private Map<Country, Map<String, Double>> glsks;
         private Map<Country, Double> netPositions;
-        private final ContingencyValue<LoadFlowRunningService.Result> acLoadFlowResult = new ContingencyValue<>();
+        private final ContingencyValue<LoadFlowResult> acLoadFlowResult = new ContingencyValue<>();
         private final ContingencyValue<Boolean> acLoadFlowFallbackHasBeenActivated = new ContingencyValue<>();
-        private final ContingencyValue<LoadFlowRunningService.Result> dcLoadFlowResult = new ContingencyValue<>();
+        private final ContingencyValue<LoadFlowResult> dcLoadFlowResult = new ContingencyValue<>();
         private final ContingencyValue<Map<String, Map<String, Double>>> nodalInjections = new ContingencyValue<>();
         private final ContingencyValue<Map<String, Map<String, Double>>> ptdfs = new ContingencyValue<>();
         private final ContingencyValue<Map<String, Map<String, Double>>> psdfs = new ContingencyValue<>();
@@ -137,7 +138,7 @@ class FlowDecompositionObserverTest {
         }
 
         @Override
-        public void computedAcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult, boolean fallbackHasBeenActivated) {
+        public void computedAcLoadFlowResults(Network network, LoadFlowResult loadFlowResult, boolean fallbackHasBeenActivated) {
             this.acLoadFlowResult.put(currentContingency, loadFlowResult);
             this.acLoadFlowFallbackHasBeenActivated.put(currentContingency, fallbackHasBeenActivated);
             computedAcNodalInjections(network);
@@ -148,7 +149,7 @@ class FlowDecompositionObserverTest {
         }
 
         @Override
-        public void computedDcLoadFlowResults(Network network, LoadFlowRunningService.Result loadFlowResult) {
+        public void computedDcLoadFlowResults(Network network, LoadFlowResult loadFlowResult) {
             this.dcLoadFlowResult.put(currentContingency, loadFlowResult);
             computedDcNodalInjections(network);
             computedDcFlows(network);
@@ -366,12 +367,12 @@ class FlowDecompositionObserverTest {
 
     private static void validateObserverReportLoadFlowResult(ObserverReport report, List<String> contingencyIds) {
         for (var contingencyId : contingencyIds) {
-            LoadFlowRunningService.Result contingencyAcLoadFlowResult = report.acLoadFlowResult.forContingency(contingencyId);
+            LoadFlowResult contingencyAcLoadFlowResult = report.acLoadFlowResult.forContingency(contingencyId);
             boolean contingencyAcLoadFlowFallbackHasBeenActivated = report.acLoadFlowFallbackHasBeenActivated.forContingency(contingencyId);
-            LoadFlowRunningService.Result contingencyDcLoadFlowResult = report.dcLoadFlowResult.forContingency(contingencyId);
-            assertTrue(contingencyAcLoadFlowResult.getLoadFlowResult().isFullyConverged());
-            assertEquals(contingencyAcLoadFlowResult.fallbackHasBeenActivated(), contingencyAcLoadFlowFallbackHasBeenActivated);
-            assertTrue(contingencyDcLoadFlowResult.getLoadFlowResult().isFullyConverged());
+            LoadFlowResult contingencyDcLoadFlowResult = report.dcLoadFlowResult.forContingency(contingencyId);
+            assertTrue(contingencyAcLoadFlowResult.isFullyConverged());
+            assertFalse(contingencyAcLoadFlowFallbackHasBeenActivated);
+            assertTrue(contingencyDcLoadFlowResult.isFullyConverged());
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently, while running a flow decomposition, we can only retrieve intermediate results for branches and nodes. We can't retrieve an intermediate state for a boundary node, for example.


**What is the new behavior (if this is a feature change)?**
Flow decomposition observers now have full access to the network after an AC LF and a DC LF. Therefore, the user can retrieve any information they need from the network at those states.


**Does this PR introduce a breaking change or deprecate an API?**
- [X] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [X] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Implement the new methods from the FlowDecompositionObserver interface
- computedAcLoadFlowResults
- computedDcLoadFlowResults)

As well as remove the old ones
- computedAcNodalInjections
- computedDcNodalInjections
- computedAcFlowsTerminal1
- computedAcFlowsTerminal2
- computedDcFlows
- computedAcCurrentsTerminal1
- computedAcCurrentsTerminal2)

