### PR TITLE
Decomposed Flows Observer before Rescaling

### DIFF
--- a/docs/flow_decomposition/flow-decomposition-detailed-results.md
+++ b/docs/flow_decomposition/flow-decomposition-detailed-results.md
@@ -12,7 +12,7 @@ Observers are notified of the following events:
 * when the PSDF matrix is computed (for base case or contingency)
 * when the AC loadflow is computed (for base case or contingency)
 * when the DC loadflow is computed (for base case or contingency)
-* when the flow decomposition result is being built (for base case or contingency)
+* when the flow decomposition results before rescaling are being built (for base case or contingency)
 * when the computation is done
 
 After AC and DC loadflows the observer has access to the network at that stage, as well as the loadflow result.

--- a/docs/flow_decomposition/flow-decomposition-detailed-results.md
+++ b/docs/flow_decomposition/flow-decomposition-detailed-results.md
@@ -12,10 +12,13 @@ Observers are notified of the following events:
 * when the PSDF matrix is computed (for base case or contingency)
 * when the AC loadflow is computed (for base case or contingency)
 * when the DC loadflow is computed (for base case or contingency)
+* when the flow decomposition result is being built (for base case or contingency)
 * when the computation is done
 
 After AC and DC loadflows the observer has access to the network at that stage, as well as the loadflow result.
-In this manner, it is possible to retrieve any information of the network after loadflow calculations.
+In this manner, it is possible to retrieve any information of the network after loadflow 
+calculations. Additionally, the observer has access to the decomposed flows prior to the 
+rescaling step, enabling more effective testing and analysis of the available rescaling algorithms.
 
 Note that these observers are meant to be used for testing purposes only.
 Using observers impacts calculation performance and therefore are not suitable in production environment.

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -172,8 +172,8 @@ public class FlowDecompositionComputer {
         computeAllocatedAndLoopFlows(flowDecompositionResultsBuilder, nodalInjectionsMatrix, ptdfMatrix);
         computePstFlows(network, flowDecompositionResultsBuilder, networkMatrixIndexes, psdfMatrix);
 
-        // Save the observers list to keep the decomposed flows before rescaling
-        flowDecompositionResultsBuilder.saveObserversList(observers);
+        // Add the observes to keep the decomposed flows before rescaling
+        flowDecompositionResultsBuilder.addObserversList(observers);
         flowDecompositionResultsBuilder.build(decomposedFlowRescaler, network);
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionComputer.java
@@ -172,6 +172,8 @@ public class FlowDecompositionComputer {
         computeAllocatedAndLoopFlows(flowDecompositionResultsBuilder, nodalInjectionsMatrix, ptdfMatrix);
         computePstFlows(network, flowDecompositionResultsBuilder, networkMatrixIndexes, psdfMatrix);
 
+        // Save the observers list to keep the decomposed flows before rescaling
+        flowDecompositionResultsBuilder.saveObserversList(observers);
         flowDecompositionResultsBuilder.build(decomposedFlowRescaler, network);
     }
 

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserver.java
@@ -86,6 +86,13 @@ public interface FlowDecompositionObserver {
     void computedAcLoadFlowResults(Network network, LoadFlowResult loadFlowResult, boolean fallbackHasBeenActivated);
 
     /**
+     * Called before the scaling is performed
+     *
+     * @param decomposedFlow the decomposed flow on which the scaling is performed
+     */
+    void computedPreRescalingDecomposedFlows(DecomposedFlow decomposedFlow);
+
+    /**
      * Called after a DC loadflow has been computed
      *
      * @param network the network after DC loadflow

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -18,7 +18,7 @@ import java.util.Map;
  * @author Guillaume Verger {@literal <guillaume.verger at artelys.com>}
  * @author Caio Luke {@literal <caio.luke at artelys.com>}
  */
-public class FlowDecompositionObserverList {
+class FlowDecompositionObserverList {
 
     private final List<FlowDecompositionObserver> observers;
 
@@ -32,6 +32,16 @@ public class FlowDecompositionObserverList {
 
     public void removeObserver(FlowDecompositionObserver o) {
         this.observers.remove(o);
+    }
+
+    public void addObserversFrom(FlowDecompositionObserverList otherList) {
+        for (FlowDecompositionObserver o : otherList.getObservers()) {
+            this.addObserver(o);
+        }
+    }
+
+    public List<FlowDecompositionObserver> getObservers() {
+        return this.observers;
     }
 
     public void runStart() {

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionObserverList.java
@@ -94,6 +94,12 @@ public class FlowDecompositionObserverList {
         }
     }
 
+    public void computedPreRescalingDecomposedFlows(DecomposedFlow decomposedFlow) {
+        for (FlowDecompositionObserver o : observers) {
+            o.computedPreRescalingDecomposedFlows(decomposedFlow);
+        }
+    }
+
     private void sendMatrix(MatrixNotification notification, SparseMatrixWithIndexesTriplet matrix) {
         if (observers.isEmpty()) {
             return;

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
@@ -47,7 +47,7 @@ public class FlowDecompositionResults {
         private Map<String, Double> acCurrentTerminal1;
         private Map<String, Double> acCurrentTerminal2;
         private Map<String, Double> dcReferenceFlow;
-        private FlowDecompositionObserverList observers = new FlowDecompositionObserverList();
+        private final FlowDecompositionObserverList observers = new FlowDecompositionObserverList();
 
         PerStateBuilder(String contingencyId, Set<Branch> xnecList) {
             this.xnecMap = xnecList.stream().collect(Collectors.toMap(Identifiable::getId, Function.identity()));
@@ -82,8 +82,8 @@ public class FlowDecompositionResults {
             this.dcReferenceFlow = dcReferenceFlow;
         }
 
-        void saveObserversList(FlowDecompositionObserverList observers) {
-            this.observers = observers;
+        void addObserversList(FlowDecompositionObserverList observers) {
+            this.observers.addObserversFrom(observers);
         }
 
         void build(DecomposedFlowRescaler decomposedFlowRescaler, Network network) {

--- a/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
+++ b/flow-decomposition/src/main/java/com/powsybl/flow_decomposition/FlowDecompositionResults.java
@@ -47,6 +47,7 @@ public class FlowDecompositionResults {
         private Map<String, Double> acCurrentTerminal1;
         private Map<String, Double> acCurrentTerminal2;
         private Map<String, Double> dcReferenceFlow;
+        private FlowDecompositionObserverList observers = new FlowDecompositionObserverList();
 
         PerStateBuilder(String contingencyId, Set<Branch> xnecList) {
             this.xnecMap = xnecList.stream().collect(Collectors.toMap(Identifiable::getId, Function.identity()));
@@ -79,6 +80,10 @@ public class FlowDecompositionResults {
 
         void saveDcReferenceFlow(Map<String, Double> dcReferenceFlow) {
             this.dcReferenceFlow = dcReferenceFlow;
+        }
+
+        void saveObserversList(FlowDecompositionObserverList observers) {
+            this.observers = observers;
         }
 
         void build(DecomposedFlowRescaler decomposedFlowRescaler, Network network) {
@@ -115,6 +120,7 @@ public class FlowDecompositionResults {
                     .withInternalFlow(internalFlow)
                     .withLoopFlowsMap(loopFlowsMap)
                     .build();
+            observers.computedPreRescalingDecomposedFlows(decomposedFlow);
             return decomposedFlowRescaler.rescale(decomposedFlow, network);
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
This PR adds a feature that improves the Observer in Flow Decomposition.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently, the decomposed flows (allocated, xnode, internal, loop, and PST) are not captured by the Observer during the flow decomposition process. These flows may change after the rescaling step for a given Xnexc. Ultimately, only the rescaled decomposed flows are reported.


**What is the new behavior (if this is a feature change)?**
This new feature enables observing the decomposed flows for a given Xnec before the rescaling step is performed. Similar to other Observer features, it can be valuable for testing and for gaining better insights into the functionalities of the different rescaling algorithms within the flow decomposition modules. 

The corresponding documentation has been updated to reflect this new information.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
