### PR TITLE
Fix unit tests (adapt to core-3272)

### DIFF
--- a/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/TestUtils.java
+++ b/flow-decomposition/src/test/java/com/powsybl/flow_decomposition/TestUtils.java
@@ -79,6 +79,7 @@ public final class TestUtils {
         Network network = Importers.importData("CGMES", CgmesConformity3ModifiedCatalog.microGridBE3DanglingLinesSameBoundary1Disconnected().dataSource(), null);
         network.getShuntCompensator("d771118f-36e9-4115-a128-cc3d9ce3e3da").remove();
         network.getShuntCompensator("002b0a40-3957-46db-b84a-30420083558f").remove();
+        network.getStaticVarCompensator("3c69652c-ff14-4550-9a87-b6fdaccbb5f4").remove();
         assertEquals(5, network.getBusbarSectionCount());
         assertEquals(0, network.getShuntCompensatorCount());
         assertEquals(0, network.getStaticVarCompensatorCount());
@@ -92,6 +93,7 @@ public final class TestUtils {
         network.getBusbarSection("364c9ca2-0d1d-4363-8f46-e586f8f66a8c").remove();
         network.getBusbarSection("ef45b632-3028-4afe-bc4c-a4fa323d83fe").remove();
         network.getBusbarSection("fd649fe1-bdf5-4062-98ea-bbb66f50402d").remove();
+        network.getStaticVarCompensator("3c69652c-ff14-4550-9a87-b6fdaccbb5f4").remove();
         assertEquals(0, network.getBusbarSectionCount());
         assertEquals(2, network.getShuntCompensatorCount());
         assertEquals(0, network.getStaticVarCompensatorCount());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes
- [X] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Since powsybl/powsybl-core#3272, a `StaticVarCompensator` is imported by `CgmesConformity3ModifiedCatalog.microGridBE3DanglingLinesSameBoundary1Disconnected()`.
This leads to test errors because `getMicroGridNetworkWithBusBarSectionOnly()` and `getMicroGridNetworkWithShuntCompensatorOnly()` from `TestUtils` assert that no `StaticVarCompensator` is present.


**What is the new behavior (if this is a feature change)?**
The `StaticVarCompensator` is removed in the `TestUtils` methods prior to the assertions.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
