### PR TITLE
Use secured XmlUtil.getXMLInputFactory instead of recreating and configuring a new one

### DIFF
--- a/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/data_exchange/DataExchangesXml.java
+++ b/entsoe-cgmes-balances-adjustment/src/main/java/com/powsybl/entsoe/cgmes/balances_adjustment/data_exchange/DataExchangesXml.java
@@ -19,8 +19,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.extra.Interval;
 
-import javax.xml.XMLConstants;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import java.io.InputStream;
@@ -109,13 +107,7 @@ public final class DataExchangesXml {
         Objects.requireNonNull(reader);
         var context = new ParsingContext();
         try {
-            var factory = XMLInputFactory.newInstance();
-            // disable resolving of external DTD entities
-            factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
-            factory.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);
-            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-            factory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-
+            var factory = XmlUtil.getXMLInputFactory();
             var xmlReader = factory.createXMLStreamReader(reader);
             try {
                 XmlUtil.readSubElements(xmlReader, subElementName -> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Code quality


**What is the current behavior?**
<!-- You can also link to an open issue here -->
A new `XMLInputFactory` is created and configured in `DataExchangesXml`.


**What is the new behavior (if this is a feature change)?**
Use powsybl-core's secured `XmlUtil.getXMLInputFactory()` instead.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
